### PR TITLE
fix bug 1132781

### DIFF
--- a/mdn/scrape.py
+++ b/mdn/scrape.py
@@ -78,7 +78,8 @@ inner_td = ~r"(?P<content>.*?(?=</td>))"s
 #
 # Browser Compatibility section
 #
-compat_section = _ compat_h2 _ compat_kuma _ compat_divs compat_footnotes?
+compat_section = _ compat_h2 _ compat_kuma _ compat_divs p_empty*
+    compat_footnotes?
 compat_h2 = "<h2 " _ attrs? _ ">" _ compat_title _ "</h2>"
 compat_title = ~r"(?P<content>Browser [cC]ompat[ai]bility)"
 compat_kuma = (compat_kuma_div / compat_kuma_p)
@@ -147,6 +148,8 @@ kuma_arg_rest = kuma_func_arg kuma_arg
 tr_open = "<tr" _ opt_attrs ">"
 th_open = "<th" _ opt_attrs ">"
 td_open = "<td" _ opt_attrs ">"
+
+p_empty = _ "<p>" _ "&nbsp;"* _ "</p>" _
 
 attrs = attr+
 opt_attrs = attr*
@@ -358,7 +361,7 @@ class PageVisitor(NodeVisitor):
     #
     def visit_compat_section(self, node, children):
         compat_divs = children[5]
-        footnotes = children[6][0]
+        footnotes = children[7][0]
 
         assert isinstance(compat_divs, list), type(compat_divs)
         for div in compat_divs:

--- a/mdn/tests/test_scrape.py
+++ b/mdn/tests/test_scrape.py
@@ -152,6 +152,7 @@ class ScrapeTestCase(TestCase):
   </tbody>
  </table>
 </div>
+<p>&nbsp;</p>
 """
     # From Web/CSS/background-size?raw
     # colspan="3" on the Safari column
@@ -243,6 +244,7 @@ Browser compatibility</h2>
 </div>
 """
     complex_compat_footnotes = """\
+<p>&nbsp;</p>
 <p>[1] Opera 9.5's computation of the background positioning area is incorrect\
  for fixed backgrounds.  Opera 9.5 also interprets the two-value form as a\
  horizontal scaling factor and, from appearances, a vertical <em>clipping</em>\
@@ -1624,14 +1626,14 @@ class TestScrape(ScrapeTestCase):
                      'support': 'yes'},
                 ],
             }],
-            'footnotes': {'3': (fn_3, 3757, 3830)},
+            'footnotes': {'3': (fn_3, 3771, 3844)},
             'issues': [],
             'errors': [
                 (1689, 1704, 'Unknown support text "with some bugs"'),
                 (1770, 1799,
                  'Unknown support text "but from an older CSS3 draft"'),
                 (2918, 2933, 'Unknown support text "(maybe earlier)"'),
-                (3757, 3830, 'Footnote [3] not used')
+                (3771, 3844, 'Footnote [3] not used')
             ]
         }
         self.assertScrape(self.complex_page, expected)
@@ -1737,7 +1739,7 @@ class TestScrape(ScrapeTestCase):
             (701, 730, 'Unknown support text "but from an older CSS3 draft"'),
             (1850, 1865, 'Unknown support text "(maybe earlier)"'),
             (1026, 1030, 'Footnote [50] not found'),
-            (2689, 2762, 'Footnote [3] not used'),
+            (2703, 2776, 'Footnote [3] not used'),
         ]
         self.assertEqual(expected_errors, actual['errors'])
 


### PR DESCRIPTION
 - Ignore paragraph/s with \&nbsp; or empty after Compatibility Table