### PR TITLE
Fix bug 1079920 - First pass at importing MDN data

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -8,6 +8,7 @@ source =
 omit =
     tools/client.py
     tools/download_data.py
+    tools/import_mdn.py
     tools/load_spec_data.py
     tools/load_webcompat_data.py
     tools/sample_mdn.py

--- a/.coveragerc
+++ b/.coveragerc
@@ -8,6 +8,7 @@ source =
 omit =
     tools/client.py
     tools/download_data.py
+    tools/gather_import_errors.py
     tools/import_mdn.py
     tools/load_spec_data.py
     tools/load_webcompat_data.py

--- a/.gitignore
+++ b/.gitignore
@@ -44,10 +44,8 @@ output/*/index.html
 docs/_build/*
 
 # Downloaded files
-data-human.json
-Spec2.txt
-SpecName.txt
 data/*.json
+data/*.txt
 
 # SQLite databases
 *.sqlite3

--- a/.gitignore
+++ b/.gitignore
@@ -43,9 +43,10 @@ output/*/index.html
 # Sphinx
 docs/_build/*
 
-# Downloaded files
+# Downloaded and generate files
 data/*.json
 data/*.txt
+data/*.csv
 
 # SQLite databases
 *.sqlite3

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -7,9 +7,13 @@ web-platform-compat has not been released to production yet.  The blocking
 issues for version 1 are tracked on Bugzilla_.
 
 In-progess versions are periodically deployed to Heroku at
-http://doesitwork-dev.allizom.org.  Here are some of the development
-deployments:
+http://doesitwork-dev.allizom.org and https://browsercompat.herokuapp.com.
 
+Here are some of the development deployments:
+
+* 2015-02 - Added MDN importer
+* 2014-12 - Added rest of resources, sample displays.
+  Dropped versioning pre-release.
 * 0.2.0  - 2014-10-13 - Add features, supports, pagination
 * 0.1.0d - 2014-09-29 - Add resource-level caching
 * 0.1.0c - 2014-09-16 - Add sample feature view, simplify draft API

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -7,6 +7,8 @@ recursive-include data README.txt
 recursive-include docs Makefile *.gv *.svg conf.py *.rst make.bat
 recursive-include tests *.py
 recursive-include tools *.py
+recursive-include mdn *.py
+recursive-include mdn/templates *.jinja2
 recursive-include webplatformcompat/migrations *.py
 recursive-include webplatformcompat/static *.css *.map *.eot *.svg *.ttf *.woff *.js .keep
 recursive-include webplatformcompat/templates *.html *.jinja2

--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ test-all:
 
 coverage:
 	coverage erase
-	coverage run --source webplatformcompat,tools setup.py test
+	coverage run --source mdn,webplatformcompat,tools setup.py test
 	coverage report -m
 	coverage html
 	open htmlcov/index.html

--- a/README.rst
+++ b/README.rst
@@ -12,6 +12,8 @@ web-platform-compat
     :target: https://heroku.com/deploy?template=https://github.com/jwhitlock/web-platform-compat
     :alt: Deploy
 
+.. Omit badges from docs
+
 The Web Platform Compatibility API will support compatibility data on the
 `Mozilla Developer Network`_.  This currently takes the form of browser
 compatibility tables, such as the one on the `CSS display property`_.

--- a/README.rst
+++ b/README.rst
@@ -12,9 +12,9 @@ web-platform-compat
     :target: https://heroku.com/deploy?template=https://github.com/jwhitlock/web-platform-compat
     :alt: Deploy
 
-The Web Platform Compatibility API will support compatability data on the
+The Web Platform Compatibility API will support compatibility data on the
 `Mozilla Developer Network`_.  This currently takes the form of browser
-compatability tables, such as the one on the `CSS display property`_.
+compatibility tables, such as the one on the `CSS display property`_.
 The API will help centralize this data, and allow it to be kept consistant
 across languages and different presentations.
 

--- a/app.json
+++ b/app.json
@@ -1,6 +1,6 @@
 {
     "name": "web-platform-compat",
-    "description": "Data store and API for web platform compatability data.",
+    "description": "Data store and API for web platform compatibility data.",
     "repository": "https://github.com/jwhitlock/web-platform-compat",
     "keywords": ["python", "django", "mozilla"],
     "env": {

--- a/docs/draft/issues.rst
+++ b/docs/draft/issues.rst
@@ -2,7 +2,7 @@ Issues
 ======
 
 This draft API reflects a good guess at a useful, efficent API for storing
-user-contributed compatability data.  Some of the guesses are better than
+user-contributed compatibility data.  Some of the guesses are better than
 others.  This section highlights the areas where more experienced opinions
 are welcome, and areas where more work is expected.
 
@@ -142,7 +142,7 @@ Unresolved Issues
 Interesting MDN Pages
 ---------------------
 
-These MDN pages represent use cases for compatability data.  They may suggest
+These MDN pages represent use cases for compatibility data.  They may suggest
 features to add, or existing features that will be dropped.
 
 * `Web/HTML/Element/address`_ - A typical "simple" example.  However, the name

--- a/docs/draft/resources.rst
+++ b/docs/draft/resources.rst
@@ -838,7 +838,7 @@ as the value ``cover`` for the CSS ``background-size`` property.  It could be
 a heirarchical group of related technologies, such as the CSS
 ``background-size`` property or the set of all CSS properties.  Some features
 correspond to a page on MDN_, which will display the list of specifications
-and a browser compatability table of the sub-features.
+and a browser compatibility table of the sub-features.
 
 The **features** representation includes:
 

--- a/docs/draft/views.rst
+++ b/docs/draft/views.rst
@@ -1134,9 +1134,84 @@ to the feature_.  This will facilitate displaying a history of
 the compatibility tables, for the purpose of reviewing changes and reverting
 vandalism.
 
+Updating View with PUT
+~~~~~~~~~~~~~~~~~~~~~~
+
+`view_features` supports PUT for bulk updates of support data.  Here is a simple
+example that adds a new subfeature without support:
+
+.. code-block:: http
+
+    PUT /api/v1/view_features/html-element-address HTTP/1.1
+    Host: browsersupports.org
+    Content-Type: application/vnd.api+json
+    Authorization: Bearer mF_9.B5f-4.1JqM
+
+.. code-block:: json
+
+    {
+        "features": {
+            "id": "816",
+            "slug": "html-element-address",
+            "mdn_uri": {
+                "en": "https://developer.mozilla.org/en-US/docs/Web/HTML/Element/address"
+            },
+            "experimental": false,
+            "standardized": true,
+            "stable": true,
+            "obsolete": false,
+            "name": "address",
+            "links": {
+                "sections": ["746", "421", "70"],
+                "supports": [],
+                "parent": "800",
+                "children": ["191"],
+                "history_current": "216",
+                "history": ["216"]
+            }
+        },
+        "linked": {
+            "features": [
+                {
+                    "id": "_New Subfeature",
+                    "slug": "html-address-new-subfeature",
+                    "name": {
+                        "en": "New Subfeature"
+                    },
+                    "links": {
+                        "parent": "816"
+                    }
+                }
+            ]
+        }
+    }
+
+The response is the feature view with new and updated items, or an error
+response.
+
+This is a trivial use case, which would be better implemented by creating the
+feature_ directly, but it can be extended to bulk updates of existing feature
+views, or for first-time importing of subfeatures and support data.  It has
+some quirks:
+
+* New items should be identified with an ID starting with an underscore
+  (``_``).  Relations to new items should use the underscored IDs.
+* Only feature_, support_, and section_ resources can be added or updated.
+  Features must be the target feature or a descendant, and supports and
+  sections are restricted to those features.
+* Deletions are not supported.
+* Other resources (browsers_, versions_, etc) can not be added or changed.
+  This includes adding links to new resources.
+
+Once the MDN import is complete, this PUT interface will be deprecated in
+favor of direct POST and PUT to the standard resource API.
+
+.. _browsers: resources.html#browsers
 .. _feature: resources.html#features
-.. _support: resources.html#versions-feature
+.. _section: resources.html#sections
+.. _support: resources.html#supports
 .. _version: resources.html#versions
+.. _versions: resources.html#versions
 
 .. _changeset: change-control#changeset
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -3,7 +3,12 @@
    You can adapt this file completely to your liking, but it should at least
    contain the root `toctree` directive.
 
+=============================
+web-platform-compat
+=============================
+
 .. include:: ../README.rst
+    :start-after: .. Omit badges from docs
 
 Contents:
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -9,8 +9,9 @@ Install Django Project
 2. Create virtualenv
 3. Install dependencies via pip
 4. Customize with environment variables (see ``wpcsite/settings.py``)
-5. Setup database, add superuser account (``./manage.py syncdb``)
-6. Run it (``./manage.py runserver``)
+5. Setup database, add superuser account (``./manage.py migrate``)
+6. Optionally, run memcached_ for improved performance
+7. Run it (``./manage.py runserver``)
 
 Install in Heroku
 -----------------
@@ -25,11 +26,49 @@ Install in Heroku
 
 Load Data
 ---------
+There are several ways to get data into your API:
+
+1. Load data from the github export
+2. Load data from another webcompat server
+3. Load sample data from the `WebPlatform project`_ and MDN_
+
+Load from GitHub
+****************
+The data on browsercompat.herokuapp.com_ is archived in the
+`browsercompat-data`_ github repo, and this is the fastest way to get data
+into your empty API:
+
+1. Clone the github repo (``git clone https://github.com/jwhitlock/browsercompat-data.git``)
+2. Run the API (``./manage.py runserver``)
+3. Import the data (``upload_data.py --data /path/to/browsercompat-data/data``)
+
+Load from another webcompat server
+**********************************
+If you have read access to a webcompat server that you'd like to clone, you
+can grab the data for your own server.
+
+1. Download the data (``download_data.py --api https://browsercompat.example.com``)
+2. Run the API (``./manage.py runserver``)
+3. Import the data (``upload_data.py``)
+
+Load Sample Data
+****************
+The `WebPlaform project` imported data from MDN_, and stored the formatted
+compatibility data in a `github project`.  There is a lot of data that was
+not imported, so it's not a good data source for re-displaying on MDN.
+However, combining this data with specification data from MDN will create
+a good data set for testing the API at scale.
+
 To load sample data:
 
-1. Run without instance cache (``USE_DRF_INSTANCE_CACHE=0 ./manage.py runserver``)
-2. Load subset of webplatform_ data (``tools/load_webcompat_data.py``) or full
+1. Run the API (``./manage.py runserver``)
+2. Load a subset of the WebPlatform data (``tools/load_webcompat_data.py``) or full
    set of data (``tools/load_webcompat.py --all-data``)
 3. Load specification data (``tools/load_spec_data.py``)
 
-.. _webplatform: https://github.com/webplatform/compatibility-data
+.. _memcached: http://memcached.org
+.. _`WebPlatform project`: http://www.webplatform.org
+.. _MDN: https://developer.mozilla.org/en-US/
+.. _`github project`: https://github.com/webplatform/compatibility-data
+.. _browsercompat.herokuapp.com: https://browsercompat.herokuapp.com
+.. _`browsercompat-data`: https://github.com/jwhitlock/browsercompat-data

--- a/docs/tools.rst
+++ b/docs/tools.rst
@@ -26,7 +26,7 @@ import::
 
 load_webcompat_data.py
 ----------------------
-Initialize with compatability data from the webplatform_ project. Usage::
+Initialize with compatibility data from the webplatform_ project. Usage::
 
     $ tools/load_webcompat_data.py [--api <API>] [--user <USER>] [-vq] [--all-data]
 
@@ -38,7 +38,7 @@ Initialize with compatability data from the webplatform_ project. Usage::
 * ``-q`` `(optional)`: Only print warnings
 * ``--all-data`` `(optional)`: Import all data, rather than a subset
 
-This script requires a fresh database (no compatability data) and a user with
+This script requires a fresh database (no compatibility data) and a user with
 write access.  The bulk import will result in cascading cache invalidations,
 which can be avoided by running the server without cached instances during the
 import::

--- a/docs/tools.rst
+++ b/docs/tools.rst
@@ -3,9 +3,38 @@ Tools
 
 Some potentially useful scripts can be found in the /tools folder:
 
+download_data.py
+----------------
+Download data from API. Usage::
+
+    $ tools/download_data.py [--api API] [-vq] [--data DATA]
+
+* ``--api <API>`` `(optional)`: Set the base URL of the API
+  (default: `http://localhost:8000`)
+* ``-v`` `(optional)`: Print debug information
+* ``-q`` `(optional)`: Only print warnings
+* ``--data <DATA>`` `(optional)`: Set the output data folder
+  (default: data subfolder in the working copy)
+
+This will create several files (browsers.json, versions.json, etc.) that
+represent the API resources without pagination.
+
+import_mdn.py
+-------------
+Import features from MDN, or reparse imported features. Usage::
+
+    $ tools/import_mdn.py [--api API] [--user USER] [-vq]
+
+* ``--api <API>`` `(optional)`: Set the base URL of the API
+  (default: `http://localhost:8000`)
+* ``--user <USER>`` `(optional)`: Set the username to use on the API
+  (default: prompt for username)
+* ``-v`` `(optional)`: Print debug information
+* ``-q`` `(optional)`: Only print warnings
+
 load_spec_data.py
 -----------------
-Initialize with specification data from MDN's SpecName_ and Spec2_.  Usage::
+Import specification data from MDN's SpecName_ and Spec2_.  Usage::
 
     $ tools/load_spec_data.py [--api <API>] [--user <USER>] [-vq] [--all-data]
 
@@ -16,17 +45,9 @@ Initialize with specification data from MDN's SpecName_ and Spec2_.  Usage::
 * ``-v`` `(optional)`: Print debug information
 * ``-q`` `(optional)`: Only print warnings
 
-This script requires a fresh database (no specification data) and a user with
-write access.  The bulk import will result in cascading cache invalidations,
-which can be avoided by running the server without cached instances during the
-import::
-
-    $ USE_DRF_INSTANCE_CACHE=0 ./manage.py runserver
-
-
 load_webcompat_data.py
 ----------------------
-Initialize with compatibility data from the webplatform_ project. Usage::
+Initialize with compatibility data from the WebPlatform_ project. Usage::
 
     $ tools/load_webcompat_data.py [--api <API>] [--user <USER>] [-vq] [--all-data]
 
@@ -38,20 +59,32 @@ Initialize with compatibility data from the webplatform_ project. Usage::
 * ``-q`` `(optional)`: Only print warnings
 * ``--all-data`` `(optional)`: Import all data, rather than a subset
 
-This script requires a fresh database (no compatibility data) and a user with
-write access.  The bulk import will result in cascading cache invalidations,
-which can be avoided by running the server without cached instances during the
-import::
-
-    $ USE_DRF_INSTANCE_CACHE=0 ./manage.py runserver
-
-
 sample_mdn.py
 -------------
 Load random pages from MDN in your browser.  Usage::
 
     $ tools/sample_mdn.py
 
+upload_data.py
+--------------
+Upload data to the API.  Usage::
+
+    $ tools/upload_data.py [--api API] [--user USER] [-vq] [--data DATA]
+
+* ``--api <API>`` `(optional)`: Set the base URL of the API
+  (default: `http://localhost:8000`)
+* ``--user <USER>`` `(optional)`: Set the username to use on the API
+  (default: prompt for username)
+* ``-v`` `(optional)`: Print debug information
+* ``-q`` `(optional)`: Only print warnings
+* ``--data <DATA>`` `(optional)`: Set the output data folder
+  (default: data subfolder in the working copy)
+
+This will load the local resources from files (browsers.json, versions.json, etc),
+download the resources from the API, and upload the changes to make the API
+match the local resource files.
+
+
 .. _SpecName: https://developer.mozilla.org/en-US/docs/Template:SpecName
 .. _Spec2: https://developer.mozilla.org/en-US/docs/Template:Spec2
-.. _webplatform: https://github.com/webplatform/compatibility-data
+.. _WebPlatform: https://github.com/webplatform/compatibility-data

--- a/mdn/__init__.py
+++ b/mdn/__init__.py
@@ -1,0 +1,1 @@
+"""Tools for migrating data from Mozilla Developer Network."""

--- a/mdn/admin.py
+++ b/mdn/admin.py
@@ -1,0 +1,8 @@
+"""Admin interface for mdn app."""
+from django.contrib import admin
+
+from .models import FeaturePage, PageMeta, TranslatedContent
+
+admin.site.register(FeaturePage)
+admin.site.register(PageMeta)
+admin.site.register(TranslatedContent)

--- a/mdn/helpers.py
+++ b/mdn/helpers.py
@@ -6,6 +6,8 @@ This file is loaded by jingo and must be named helpers.py
 from jinja2 import contextfunction, Markup
 from jingo import register
 
+from .views import can_create, can_refresh
+
 
 def page_list(page_obj):
     """Determine list of pages for pagination control.
@@ -108,3 +110,15 @@ def pagination_control(context, page_obj, url):
   </ul>
 </nav>
 """.format(previous_nav=previous_nav, page_nav=page_nav, next_nav=next_nav))
+
+
+@register.function
+@contextfunction
+def can_create_mdn_import(context, user):
+    return can_create(user)
+
+
+@register.function
+@contextfunction
+def can_refresh_mdn_import(context, user):
+    return can_refresh(user)

--- a/mdn/helpers.py
+++ b/mdn/helpers.py
@@ -122,3 +122,9 @@ def can_create_mdn_import(context, user):
 @contextfunction
 def can_refresh_mdn_import(context, user):
     return can_refresh(user)
+
+
+@register.function
+@contextfunction
+def can_reparse_mdn_import(context, user):
+    return can_create(user)

--- a/mdn/helpers.py
+++ b/mdn/helpers.py
@@ -1,0 +1,110 @@
+"""Helper functions for Jinja2 templates
+
+This file is loaded by jingo and must be named helpers.py
+"""
+
+from jinja2 import contextfunction, Markup
+from jingo import register
+
+
+def page_list(page_obj):
+    """Determine list of pages for pagination control.
+
+    The goals are:
+    - If less than 8 pages, show them all
+    - Show three numbers around current page
+    - Always have 7 entries (don't move click targets)
+    Return is a list like [1, None, 5, 6, 7, None, 66].
+
+    In separate function to facilitate unit testing.
+    """
+    paginator = page_obj.paginator
+    current = page_obj.number
+    end = paginator.num_pages
+    if end <= 7:
+        return paginator.page_range
+
+    if current <= 4:
+        pages = list(range(1, max(6, current + 2))) + [None, end]
+    elif current >= (end - 3):
+        pages = [1, None] + list(range(end - 4, end + 1))
+    else:
+        pages = [1, None] + list(range(current - 1, current + 2)) + [None, end]
+    return pages
+
+
+@register.function
+@contextfunction
+def pagination_control(context, page_obj, url):
+    """Add a bootstrap-style pagination control.
+
+    The basic pagination control is:
+    << - previous page
+    1, 2 - First two pages
+    ... - Break
+    n-1, n, n+1 - Current page and context
+    total-1, total - End pages
+    >> - Next page
+
+    This breaks down when the current page is low or high, or the total
+    number of pages is low.  So, done as a function.
+    """
+    if not page_obj.has_other_pages():
+        return ""
+    if page_obj.has_previous():
+        prev_page = page_obj.previous_page_number()
+        if prev_page == 1:
+            prev_url = url
+        else:
+            prev_url = url + '?page=%d' % prev_page
+        previous_nav = (
+            '<li><a href="{prev_url}" aria-label="Previous">'
+            '<span aria-hidden="true">&laquo;</span></a></li>'
+        ).format(prev_url=prev_url)
+    else:
+        previous_nav = (
+            '<li class="disabled"><span aria-hidden="true">&laquo;</span>'
+            '</li>')
+
+    pages = page_list(page_obj)
+    page_navs = []
+    current = page_obj.number
+    for page in pages:
+        if page is None:
+            page_navs.append(
+                '<li class="disabled"><span aria-hidden="true">&hellip;</span>'
+                '</li>')
+            continue
+        if page == current:
+            active = ' class="active"'
+        else:
+            active = ''
+        if page == 1:
+            page_query = ''
+        else:
+            page_query = "?page=%d" % page
+        page_navs.append(
+            '<li{active}><a href="{url}{page_query}">'
+            '{page}</a></li>'.format(
+                active=active, url=url, page_query=page_query, page=page))
+    page_nav = "\n    ".join(page_navs)
+
+    if page_obj.has_next():
+        next_nav = """<li>
+      <a href="{url}?page={page}" aria-label="Next">
+        <span aria-hidden="true">&raquo;</span>
+      </a>
+    </li>""".format(url=url, page=page_obj.next_page_number())
+    else:
+        next_nav = """\
+    <li class="disabled"><span aria-hidden="true">&raquo;</span></li>"""
+
+    return Markup("""\
+<nav>
+  <ul class="pagination">
+    {previous_nav}
+    {page_nav}
+    {next_nav}
+  </ul>
+</nav>
+""".format(previous_nav=previous_nav, page_nav=page_nav, next_nav=next_nav))

--- a/mdn/helpers.py
+++ b/mdn/helpers.py
@@ -128,3 +128,9 @@ def can_refresh_mdn_import(context, user):
 @contextfunction
 def can_reparse_mdn_import(context, user):
     return can_create(user)
+
+
+@register.function
+@contextfunction
+def can_commit_mdn_import(context, user):
+    return can_create(user)

--- a/mdn/migrations/0001_initial.py
+++ b/mdn/migrations/0001_initial.py
@@ -1,0 +1,64 @@
+# -*- coding: utf-8 -*-
+# flake8: noqa
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+import mdn.models
+import django.utils.timezone
+import django_extensions.db.fields
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('webplatformcompat', '0004_drop_field_feature_mdn_path'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='FeaturePage',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('url', models.URLField(help_text='URL of the English translation of an MDN page', unique=True, db_index=True, validators=[mdn.models.validate_mdn_url])),
+                ('status', models.IntegerField(default=0, help_text='Status of MDN Parsing process', choices=[(0, 'Starting Import'), (1, 'Fetching Metadata'), (2, 'Fetching MDN pages'), (3, 'Parsing MDN pages'), (4, 'Parsing Complete'), (5, 'Scraping Failed')])),
+                ('modified', django_extensions.db.fields.ModificationDateTimeField(default=django.utils.timezone.now, help_text='Last modification time', db_index=True, editable=False, blank=True)),
+                ('raw_data', models.TextField(help_text='JSON-encoded parsed content')),
+                ('has_issues', models.BooleanField(default=False, help_text='Issues found when parsing the page')),
+                ('feature', models.ForeignKey(to='webplatformcompat.Feature', help_text='Feature in API', unique=True)),
+            ],
+            options={
+            },
+            bases=(models.Model,),
+        ),
+        migrations.CreateModel(
+            name='PageMeta',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('path', models.CharField(help_text='Path of MDN page', max_length=255)),
+                ('crawled', django_extensions.db.fields.ModificationDateTimeField(default=django.utils.timezone.now, help_text='Time when the content was retrieved', editable=False, blank=True)),
+                ('raw', models.TextField(help_text='Raw content of the page')),
+                ('status', models.IntegerField(default=0, help_text='Status of MDN fetching process', choices=[(0, 'Starting Fetch'), (1, 'Fetching Page'), (2, 'Fetched Page'), (3, 'Error Fetching Page')])),
+                ('page', models.ForeignKey(to='mdn.FeaturePage')),
+            ],
+            options={
+                'abstract': False,
+            },
+            bases=(models.Model,),
+        ),
+        migrations.CreateModel(
+            name='TranslatedContent',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('path', models.CharField(help_text='Path of MDN page', max_length=255)),
+                ('crawled', django_extensions.db.fields.ModificationDateTimeField(default=django.utils.timezone.now, help_text='Time when the content was retrieved', editable=False, blank=True)),
+                ('raw', models.TextField(help_text='Raw content of the page')),
+                ('status', models.IntegerField(default=0, help_text='Status of MDN fetching process', choices=[(0, 'Starting Fetch'), (1, 'Fetching Page'), (2, 'Fetched Page'), (3, 'Error Fetching Page')])),
+                ('locale', models.CharField(help_text='Locale for page translation', max_length=5, db_index=True)),
+                ('page', models.ForeignKey(to='mdn.FeaturePage')),
+            ],
+            options={
+                'abstract': False,
+            },
+            bases=(models.Model,),
+        ),
+    ]

--- a/mdn/models.py
+++ b/mdn/models.py
@@ -140,6 +140,10 @@ class FeaturePage(models.Model):
                 ('parent', str(self.feature.parent_id)),
                 ('children', []),
             )))))
+        for t in self.translations():
+            if t.locale != 'en-US':
+                feature['mdn_uri'][t.locale] = t.url()
+
         view_feature = OrderedDict((
             ('features', feature),
             ('linked', OrderedDict((
@@ -163,6 +167,7 @@ class FeaturePage(models.Model):
                     ("phase", "Starting Import"),
                     ("errors", []),
                     ("raw", None)))))))))
+
         self.data = view_feature
         self.has_issues = False
         return view_feature

--- a/mdn/models.py
+++ b/mdn/models.py
@@ -1,0 +1,262 @@
+# -*- coding: utf-8 -*-
+"""Model definitions for MDN migration app."""
+
+from __future__ import unicode_literals
+from collections import OrderedDict
+from json import dumps, loads
+
+from django.conf import settings
+from django.core.exceptions import ValidationError
+from django.db import models
+from django.utils.encoding import python_2_unicode_compatible
+from django.utils.html import escape
+from django.utils.six.moves.urllib_parse import urlparse
+from django.utils.timesince import timesince
+from django_extensions.db.fields import ModificationDateTimeField
+
+from webplatformcompat.models import Feature
+
+
+def validate_mdn_url(value):
+    """Validate than a URL is an acceptable MDN URL."""
+    disallowed_chars = '?$#'
+    for c in disallowed_chars:
+        if c in value:
+            raise ValidationError('"?" is not allowed in URL')
+    allowed_prefix = False
+    for allowed in settings.MDN_ALLOWED_URLS:
+        allowed_prefix = allowed_prefix or value.startswith(allowed)
+    if not allowed_prefix:
+        raise ValidationError(
+            '%s does not start with an allowed URL prefix' % value)
+
+
+@python_2_unicode_compatible
+class FeaturePage(models.Model):
+    """A page on MDN describing a feature."""
+    url = models.URLField(
+        help_text="URL of the English translation of an MDN page",
+        db_index=True, unique=True, validators=[validate_mdn_url])
+    feature = models.ForeignKey(
+        Feature, help_text="Feature in API", unique=True)
+
+    STATUS_STARTING = 0
+    STATUS_META = 1
+    STATUS_PAGES = 2
+    STATUS_PARSING = 3
+    STATUS_PARSED = 4
+    STATUS_ERROR = 5
+    STATUS_CHOICES = (
+        (STATUS_STARTING, "Starting Import"),
+        (STATUS_META, "Fetching Metadata"),
+        (STATUS_PAGES, "Fetching MDN pages"),
+        (STATUS_PARSING, "Parsing MDN pages"),
+        (STATUS_PARSED, "Parsing Complete"),
+        (STATUS_ERROR, "Scraping Failed"),
+    )
+    status = models.IntegerField(
+        help_text="Status of MDN Parsing process",
+        default=STATUS_STARTING, choices=STATUS_CHOICES)
+    modified = ModificationDateTimeField(
+        help_text="Last modification time", db_index=True)
+    raw_data = models.TextField(help_text="JSON-encoded parsed content")
+    has_issues = models.BooleanField(
+        help_text="Issues found when parsing the page", default=False)
+
+    def __str__(self):
+        return "%s for %s" % (self.get_status_display(), self.slug())
+
+    def domain(self):
+        """Protocol + domain portion of URL"""
+        url_bits = urlparse(self.url)
+        return "%s://%s" % (url_bits.scheme, url_bits.netloc)
+
+    def path(self):
+        """Path portion of URL"""
+        return urlparse(self.url).path
+
+    def slug(self):
+        path = self.path()
+        prefix = '/en-US/docs/'
+        assert path.startswith(prefix)
+        return path[len(prefix):]
+
+    def same_since(self):
+        """Return a string indicating when the object was changes"""
+        return timesince(self.modified) + " ago"
+
+    def meta(self):
+        """Get the page Meta section."""
+        meta, created = self.pagemeta_set.get_or_create(defaults={
+            'path': self.path() + '$json',
+            'raw': '',
+            'status': Content.STATUS_STARTING})
+        return meta
+
+    def translations(self):
+        """Get the page translations, after fetching the meta data."""
+        meta = self.meta()
+        translations = []
+        for locale, path in meta.locale_paths():
+            content, created = self.translatedcontent_set.get_or_create(
+                locale=locale, defaults={
+                    'path': path,
+                    'raw': '',
+                    'status': TranslatedContent.STATUS_STARTING})
+            translations.append(content)
+        return translations
+
+    def reset(self, delete_cache=True):
+        """Reset to initial state
+
+        drop_cache - Delete cached MDN content
+        """
+        self.status = FeaturePage.STATUS_STARTING
+        self.reset_data()
+        self.save()
+        meta = self.meta()
+        meta.status = meta.STATUS_STARTING
+        meta.save()
+        for t in self.translatedcontent_set.all():
+            if delete_cache or (t.status == t.STATUS_ERROR):
+                t.status = t.STATUS_STARTING
+                t.raw = ""
+                t.save()
+
+    def reset_data(self):
+        """Reset JSON data to initial state"""
+        feature = OrderedDict((
+            ('id', str(self.feature.id)),
+            ('slug', self.feature.slug),
+            ('mdn_uri', OrderedDict((('en', self.url),))),
+            ('experimental', self.feature.experimental),
+            ('standardized', self.feature.standardized),
+            ('stable', self.feature.stable),
+            ('obsolete', self.feature.obsolete),
+            ('name', self.feature.name),
+            ('links', OrderedDict((
+                ('sections', []),
+                ('supports', []),
+                ('parent', str(self.feature.parent_id)),
+                ('children', []),
+            )))))
+        view_feature = OrderedDict((
+            ('features', feature),
+            ('linked', OrderedDict((
+                ('browsers', []),
+                ('versions', []),
+                ('supports', []),
+                ('maturities', []),
+                ('specifications', []),
+                ('sections', []),
+                ('features', []),
+            ))),
+            ('meta', OrderedDict((
+                ("compat_table", OrderedDict((
+                    ("supports", OrderedDict()),
+                    ("tabs", []),
+                    ("pagination", OrderedDict()),
+                    ("languages", []),
+                    ("footnotes", OrderedDict()),
+                ))),
+                ("scrape", OrderedDict((
+                    ("phase", "Starting Import"),
+                    ("errors", []),
+                    ("raw", None)))))))))
+        self.data = view_feature
+        self.has_issues = False
+        return view_feature
+
+    @property
+    def data(self):
+        """Scraped data in JSON-API format."""
+        try:
+            data = loads(self.raw_data, object_pairs_hook=OrderedDict)
+        except (ValueError, TypeError):
+            data = {}
+        if not data:
+            data = self.reset_data()
+        return data
+
+    @data.setter
+    def data(self, value):
+        """Serialize the data for storage"""
+        self.raw_data = dumps(value, indent=2)
+
+    def add_error(self, error, safe=False):
+        """Add an error to the JSON data"""
+        data = self.data
+        errors = data['meta']['scrape']['errors']
+        if safe:
+            err = error
+        else:
+            err = '<pre>%s</pre>' % escape(error)
+        if err not in errors:
+            errors.append(err)
+        self.data = data
+        self.has_issues = True
+
+    @models.permalink
+    def get_absolute_url(self):
+        return ('mdn.views.feature_page_detail', [str(self.id)])
+
+
+@python_2_unicode_compatible
+class Content(models.Model):
+    """The content of an MDN page."""
+    page = models.ForeignKey(FeaturePage)
+    path = models.CharField(help_text="Path of MDN page", max_length=255)
+    crawled = ModificationDateTimeField(
+        help_text="Time when the content was retrieved")
+    raw = models.TextField(help_text="Raw content of the page")
+    STATUS_STARTING = 0
+    STATUS_FETCHING = 1
+    STATUS_FETCHED = 2
+    STATUS_ERROR = 3
+    STATUS_CHOICES = (
+        (STATUS_STARTING, "Starting Fetch"),
+        (STATUS_FETCHING, "Fetching Page"),
+        (STATUS_FETCHED, "Fetched Page"),
+        (STATUS_ERROR, "Error Fetching Page"),
+    )
+    status = models.IntegerField(
+        help_text="Status of MDN fetching process",
+        default=STATUS_STARTING, choices=STATUS_CHOICES)
+
+    class Meta:
+        abstract = True
+
+    def url(self):
+        return self.page.domain() + self.path
+
+    def __str__(self):
+        return "%s retrieved %s ago" % (self.path, timesince(self.crawled))
+
+
+class PageMeta(Content):
+    """The metadata for a page, retrieved by adding $json to the URL."""
+
+    def data(self):
+        """Get the metdata for the page"""
+        assert self.status == self.STATUS_FETCHED
+        return loads(self.raw)
+
+    def locale_paths(self):
+        """Get the locals and their paths.
+
+        If the meta section isn't fetched, will return an empty list.
+        """
+        if self.status != self.STATUS_FETCHED:
+            return []
+        meta = self.data()
+        locale_paths = [(meta['locale'], meta['url'])]
+        for t in meta['translations']:
+            locale_paths.append((t['locale'], t['url']))
+        return locale_paths
+
+
+class TranslatedContent(Content):
+    """The raw translated content of a MDN feature page."""
+    locale = models.CharField(
+        help_text="Locale for page translation",
+        max_length=5, db_index=True)

--- a/mdn/scrape.py
+++ b/mdn/scrape.py
@@ -478,7 +478,7 @@ class PageVisitor(NodeVisitor):
         # Filter attributes
         attr_dict = {}
         for name, value in attrs:
-            if name not in expected:  # pragma: nocover
+            if name not in expected:
                 self.issues.append((
                     node.start, node.end,
                     "Unexpected attribute <%s %s=\"%s\">" % (

--- a/mdn/scrape.py
+++ b/mdn/scrape.py
@@ -38,7 +38,7 @@ from webplatformcompat.models import (
 
 
 # Parsimonious grammar for an MDN page
-page_grammar = (
+page_grammar = Grammar(
     r"""
 # A whole raw MDN page
 doc = other_text other_section* spec_section? compat_section?
@@ -240,9 +240,8 @@ class PageVisitor(NodeVisitor):
                 start = section_node.start + h2.start()
                 # end = section_node.end + h2.end()
                 text = section_node.text[h2.start():]
-                grammar = Grammar(page_grammar)
                 try:
-                    grammar[section].parse(text)
+                    page_grammar[section].parse(text)
                 except ParseError as pe:
                     rule = pe.expr
                     description = (
@@ -1136,9 +1135,8 @@ def scrape_page(mdn_page, feature, locale='en'):
         data['errors'].append('No <h2> found in page')
         return data
 
-    grammar = Grammar(page_grammar)
     try:
-        page_parsed = grammar.parse(mdn_page)
+        page_parsed = page_grammar.parse(mdn_page)
     except IncompleteParseError as ipe:
         error = (
             ipe.pos, end_of_line(ipe.text, ipe.pos),

--- a/mdn/scrape.py
+++ b/mdn/scrape.py
@@ -190,28 +190,35 @@ class PageVisitor(NodeVisitor):
 
     def feature_id_and_slug(self, name):
         """Get or create the feature ID and slug given a name."""
+        def normalized(n):
+            return n.lower().replace('<code>', '').replace('</code>', '')
+        nname = normalized(name)
+
         # Initialize Feature IDs
         if not self._feature_data:
             self._feature_data = {}
             for feature in Feature.objects.filter(parent=self.feature):
-                name = feature.name.get(self.locale, feature.name['en'])
-                self._feature_data[name] = (feature.id, feature.slug)
+                if 'zxx' in feature.name:
+                    fname = feature.name['zxx']
+                else:
+                    fname = feature.name.get(self.locale, feature.name['en'])
+                fname = normalized(fname)
+                self._feature_data[fname] = (feature.id, feature.slug)
 
         # Select the Feature ID and slug
-        if name not in self._feature_data:
-            feature_id = '_' + name
+        if nname not in self._feature_data:
+            feature_id = '_' + nname
             attempt = 0
             feature_slug = None
-            plain_name = name.replace('<code>', '').replace('</code>', '')
             while not feature_slug:
-                base_slug = self.feature.slug + '_' + plain_name
+                base_slug = self.feature.slug + '_' + nname
                 feature_slug = slugify(base_slug, suffix=attempt)
                 if Feature.objects.filter(slug=feature_slug).exists():
                     attempt += 1
                     feature_slug = ''
-            self._feature_data[name] = (feature_id, feature_slug)
+            self._feature_data[nname] = (feature_id, feature_slug)
 
-        return self._feature_data[name]
+        return self._feature_data[nname]
 
     def cell_to_feature(self, cell):
         # name = cell['content']

--- a/mdn/scrape.py
+++ b/mdn/scrape.py
@@ -306,8 +306,20 @@ def scrape_feature_page(fp):
             spec_id = '_' + row['specification.mdn_key']
             spec_content = OrderedDict((
                 ('id', spec_id),
-                ('mdn_key', row['specification.mdn_key'])))
+                ('mdn_key', row['specification.mdn_key']),
+                ('links', OrderedDict((
+                    ('maturity', '_unknown'),
+                    ('sections', [])
+                )))))
             specifications[spec_id] = spec_content
+
+            mat = maturities.get('_unknown', OrderedDict((
+                ('id', '_unknown'),
+                ('slug', ''),
+                ('name', {'en': 'Unknown'}),
+                ('links', {'specifications': []}))))
+            mat['links']['specifications'].append(spec_id)
+            maturities['_unknown'] = mat
 
         # Load Section
         section_id = row['section.id']

--- a/mdn/scrape.py
+++ b/mdn/scrape.py
@@ -472,6 +472,11 @@ class PageVisitor(NodeVisitor):
                 support['version'] = version_id
                 support['feature'] = feature['id']
 
+            # Footnote + prefix => support=partial
+            if (support.get('support') == 'yes' and
+                    support.get('prefix') and support.get('footnote_id')):
+                support['support'] = 'partial'
+
         if version.get('id') and support.get('id'):
             versions.append(version)
             supports.append(support)

--- a/mdn/scrape.py
+++ b/mdn/scrape.py
@@ -40,7 +40,8 @@ specname_td = "<td>" kuma_esc_start "SpecName" kuma_func_start qtext
     "</td>"
 spec2_td = "<td>" kuma_esc_start "Spec2" kuma_func_start qtext
     kuma_func_end kuma_esc_end "</td>"
-specdesc_td = "<td>" _ bare_text _ "</td>"
+specdesc_td = "<td>" _ inner_td _ "</td>"
+inner_td = ~r"(?P<content>.*?(?=</td>))"s
 
 kuma_esc_start = _ "{{" _
 kuma_func_start = "(" _
@@ -175,9 +176,6 @@ class PageVisitor(NodeVisitor):
             'section.note': desc,
             'section.id': section_id})
 
-    def visit_single_quoted_text(self, node, args):
-        return node.match.group('content')
-
     def visit_attr(self, node, children):
         ident = children[1]
         value = children[5][0]
@@ -208,9 +206,14 @@ class PageVisitor(NodeVisitor):
                   ' name="Specifications"> or no name attribute,'
                   ' actual name="%s"' % h2_name)))
 
-    visit_double_quoted_text = visit_single_quoted_text
-    visit_bare_text = visit_single_quoted_text
-    visit_ident = visit_single_quoted_text
+    def generic_visit_content(self, node, args):
+        return node.match.group('content')
+
+    visit_single_quoted_text = generic_visit_content
+    visit_double_quoted_text = generic_visit_content
+    visit_bare_text = generic_visit_content
+    visit_ident = generic_visit_content
+    visit_inner_td = generic_visit_content
 
 
 def range_error_to_html(page, start, end, reason, rule=None):

--- a/mdn/scrape.py
+++ b/mdn/scrape.py
@@ -59,11 +59,15 @@ spec_title = ~r"(?P<content>[sS]pecifications?)"
 spec_table = "<table class=\"standard-table\">" _ spec_head _ spec_body
     _ "</table>" _
 
-spec_head = "<thead>" _ "<tr>" _ th_elems _ "</tr>" _ "</thead>"
+spec_head = spec_thead_headers / spec_tbody_headers
+spec_thead_headers = "<thead>" _ spec_headers "</thead>" _ spec_tbody _
+spec_tbody_headers = spec_tbody _ spec_headers
+spec_headers =  "<tr>" _ th_elems _ "</tr>" _
 th_elems = th_elem+
 th_elem = "<th scope=\"col\">" _ (!"</th>" bare_text) _ "</th>" _
+spec_tbody = "<tbody>"
 
-spec_body = "<tbody>" _ spec_rows "</tbody>"
+spec_body = spec_rows "</tbody>"
 spec_rows = spec_row+
 spec_row = "<tr>" _ specname_td _ spec2_td _ specdesc_td _ "</tr>" _
 specname_td = "<td>" _ kuma "</td>"

--- a/mdn/scrape.py
+++ b/mdn/scrape.py
@@ -1,0 +1,362 @@
+"""Parsing Expression Grammar for MDN pages."""
+from __future__ import unicode_literals
+from collections import OrderedDict
+from itertools import chain
+
+from django.utils.html import escape
+from django.utils.six import text_type
+from parsimonious import IncompleteParseError, ParseError
+from parsimonious.grammar import Grammar
+from parsimonious.nodes import NodeVisitor
+
+from webplatformcompat.models import Section, Specification
+
+
+# Parsimonious grammar for an MDN page
+page_grammar = r"""
+doc = other_text other_section* spec_section other_section* last_section?
+
+other_text = ~r".*?(?=<h2)"s
+other_section = _ !spec_h2 other_h2 _ other_text
+other_h2 = "<h2 " _ attrs? _ ">" _ bare_text _ "</h2>"
+last_section = _ other_h2 _ ~r".*(?!=<h2)"s
+
+spec_section = _ spec_h2 _ spec_table
+spec_h2 = "<h2 " _ attrs? _ ">" _ "Specifications" _ "</h2>"
+spec_table = "<table class=\"standard-table\">" _ spec_head _ spec_body
+    _ "</table>" _
+
+spec_head = "<thead>" _ "<tr>" _ th_elems _ "</tr>" _ "</thead>"
+th_elems = th_elem+
+th_elem = "<th scope=\"col\">" _ (!"</th>" bare_text) _ "</th>" _
+old_th_elem = "<th scope=\"col\">" _ inside_th _ "</th>" _
+inside_th = !"</th>" bare_text
+
+spec_body = "<tbody>" _ spec_rows "</tbody>"
+spec_rows = spec_row+
+spec_row = "<tr>" _ specname_td _ spec2_td _ specdesc_td _ "</tr>" _
+specname_td = "<td>" kuma_esc_start "SpecName" kuma_func_start qtext
+    kuma_func_arg qtext kuma_func_arg qtext kuma_func_end kuma_esc_end
+    "</td>"
+spec2_td = "<td>" kuma_esc_start "Spec2" kuma_func_start qtext
+    kuma_func_end kuma_esc_end "</td>"
+specdesc_td = "<td>" _ bare_text _ "</td>"
+
+kuma_esc_start = _ "{{" _
+kuma_func_start = "(" _
+kuma_func_arg = _ "," _
+kuma_func_end = _ ")" _
+kuma_esc_end = _ "}}" _
+
+attrs = attr+
+attr = _ ident _ equals _ qtext _
+equals = "="
+ident = ~r"(?P<content>[a-z][a-z0-9-:]*)"
+
+text = (double_quoted_text / single_quoted_text / bare_text)
+qtext = (double_quoted_text / single_quoted_text)
+bare_text = ~r"(?P<content>[^<]*)"
+double_quoted_text = ~r'"(?P<content>[^"]*)"'
+single_quoted_text = ~r"'(?P<content>[^']*)'"
+
+_ = ~r"[ \t\r\n]*"
+"""
+
+
+def scrape_page(mdn_page, locale='en'):
+    data = {
+        'specs': [],
+        'locale': locale,
+        'issues': [],
+        'errors': [],
+    }
+    if '<h2' not in mdn_page:
+        data['errors'].append('No <h2> found in page')
+        return data
+
+    grammar = Grammar(page_grammar)
+    try:
+        page_parsed = grammar.parse(mdn_page)
+    except IncompleteParseError as ipe:  # pragma: no cover
+        error = (
+            ipe.pos, ipe.text.index('\n', ipe.pos),
+            'Unable to finish parsing MDN page, starting at this position.')
+        data['errors'].append(error)
+        return data
+    except ParseError as pe:
+        rule = pe.expr
+        error = (
+            pe.pos, pe.text.index('\n', pe.pos),
+            'Rule "%s" failed to match.  Rule definition:' % rule.name,
+            rule.as_rule())
+        data['errors'].append(error)
+        return data
+    page_data = PageVisitor().visit(page_parsed)
+
+    data['specs'] = page_data.get('specs', [])
+    data['issues'] = page_data.get('issues', [])
+    data['errors'] = page_data.get('errors', [])
+    return data
+
+
+class PageVisitor(NodeVisitor):
+    """Extract and validate data from a parsed Specification section."""
+
+    def __init__(self, locale='en'):
+        super(PageVisitor, self).__init__()
+        self.locale = locale
+        self.specs = []
+        self.issues = []
+        self.errors = []
+
+    def generic_visit(self, node, visited_children):
+        return visited_children or node
+
+    def visit_doc(self, node, children):
+        return {
+            'specs': self.specs,
+            'locale': self.locale,
+            'issues': self.issues,
+            'errors': self.errors,
+        }
+
+    visit_spec_section = visit_doc
+
+    def visit_specname_td(self, node, children):
+        key = children[4][0]
+        subpath = children[6][0]
+        name = children[8][0]
+        assert isinstance(key, text_type), type(key)
+        assert isinstance(subpath, text_type), type(subpath)
+        assert isinstance(name, text_type), type(name)
+        try:
+            spec = Specification.objects.get(mdn_key=key)
+        except Specification.DoesNotExist:
+            spec_id = None
+            self.errors.append(
+                (node.start, node.end, 'Unknown Specification "%s"' % key))
+        else:
+            spec_id = spec.id
+        return (key, spec_id, subpath, name)
+
+    def visit_spec2_td(self, node, children):
+        key = children[4][0]
+        assert isinstance(key, text_type), type(key)
+        return key
+
+    def visit_specdesc_td(self, node, children):
+        text = children[2]
+        assert isinstance(text, text_type), type(text)
+        return text
+
+    def visit_spec_row(self, node, children):
+        specname = children[2]
+        assert isinstance(specname, tuple), type(specname)
+        key, spec_id, path, name = specname
+
+        spec2_key = children[4]
+        assert isinstance(spec2_key, text_type), spec2_key
+        assert spec2_key == key, (spec2_key, key)
+
+        desc = children[6]
+        assert isinstance(desc, text_type)
+
+        section_id = None
+        if spec_id:
+            for section in Section.objects.filter(specification_id=spec_id):
+                if section.subpath.get(self.locale) == path:
+                    section_id = section.id
+                    break
+        self.specs.append({
+            'specification.mdn_key': key,
+            'specification.id': spec_id,
+            'section.subpath': path,
+            'section.name': name,
+            'section.note': desc,
+            'section.id': section_id})
+
+    def visit_single_quoted_text(self, node, args):
+        return node.match.group('content')
+
+    def visit_attr(self, node, children):
+        ident = children[1]
+        value = children[5][0]
+
+        assert isinstance(ident, text_type), type(ident)
+        assert isinstance(value, text_type), type(value)
+
+        return (ident, value)
+
+    def visit_attrs(self, node, children):
+        return children
+
+    def visit_spec_h2(self, node, children):
+        attrs_list = children[2][0]
+        attrs = dict(attrs_list)
+        h2_id = attrs.get('id')
+        if h2_id != 'Specifications':
+            self.issues.append(
+                (node.start, node.end,
+                 ('In Specifications section, expected <h3'
+                  ' id="Specifications">, actual id="%s"' % h2_id)))
+
+        h2_name = attrs.get('name')
+        if h2_name is not None and h2_name != 'Specifications':
+            self.issues.append(
+                (node.start, node.end,
+                 ('In Specifications section, expected <h3'
+                  ' name="Specifications"> or no name attribute,'
+                  ' actual name="%s"' % h2_name)))
+
+    visit_double_quoted_text = visit_single_quoted_text
+    visit_bare_text = visit_single_quoted_text
+    visit_ident = visit_single_quoted_text
+
+
+def range_error_to_html(page, start, end, reason, rule=None):
+    """Convert a range error to HTML"""
+    assert page, "Page can not be empty"
+    html_bits = ["<div><p>", escape(reason), "</p>"]
+    if rule:
+        html_bits.extend(("<p><code>", escape(rule), "</code></p>"))
+
+    # Get 2 lines of context around error
+    html_bits.append('<p>Context:<pre>')
+    start_line = page.count('\n', 0, start)
+    end_line = page.count('\n', 0, end)
+    ctx_start_line = max(0, start_line - 2)
+    ctx_end_line = min(end_line + 3, page.count('\n'))
+    digits = len(str(ctx_end_line))
+    context_lines = page.split('\n')[ctx_start_line:ctx_end_line]
+
+    # Highlight the errored portion
+    err_page_bits = []
+    err_line_count = 1
+    for p, c in enumerate(page):  # pragma: nocover
+        if c == '\n':
+            err_page_bits.append(c)
+            err_line_count += 1
+            if err_line_count > ctx_end_line:
+                break
+        elif p < start or p > end:
+            err_page_bits.append(' ')
+        else:
+            err_page_bits.append('^')
+    err_page = ''.join(err_page_bits)
+    err_lines = err_page.split('\n')[ctx_start_line:ctx_end_line]
+
+    for num, (line, err_line) in enumerate(zip(context_lines, err_lines)):
+        lnum = ctx_start_line + num
+        html_bits.append(str(lnum).rjust(digits) + ' ' + escape(line) + '\n')
+        if '^' in err_line:
+            html_bits.append('*' * digits + ' ' + err_line + '\n')
+
+    html_bits.append("</pre></p></div>")
+    return ''.join(html_bits)
+
+
+def scrape_feature_page(fp):
+    """Scrape a FeaturePage object"""
+    en_content = fp.translatedcontent_set.get(locale='en-US')
+    fp_data = fp.reset_data()
+    main_feature_id = str(fp.feature.id)
+    data = scrape_page(en_content.raw)
+    fp_data['meta']['scrape']['raw'] = data
+
+    # Load specification section data
+    specifications = OrderedDict()
+    maturities = OrderedDict()
+    sections = OrderedDict()
+    for row in data['specs']:
+        # Load Specifications and Maturity
+        spec_id = row['specification.id']
+        if spec_id:
+            spec = Specification.objects.get(id=spec_id)
+            section_ids = [
+                str(s_id) for s_id in spec.sections.values_list(
+                    'id', flat=True)]
+            spec_content = OrderedDict((
+                ('id', str(spec_id)),
+                ('slug', spec.slug),
+                ('mdn_key', spec.mdn_key),
+                ('name', spec.name),
+                ('uri', spec.uri),
+                ('links', OrderedDict((
+                    ('maturity', str(spec.maturity_id)),
+                    ('sections', section_ids)
+                )))))
+            specifications[spec_id] = spec_content
+
+            mat = spec.maturity
+            spec_ids = [
+                str(s_id) for s_id in mat.specifications.values_list(
+                    'id', flat=True)]
+            mat_content = OrderedDict((
+                ('id', str(mat.id)),
+                ('slug', mat.slug),
+                ('name', mat.name),
+                ('links', OrderedDict((
+                    ('specifications', spec_ids),
+                )))))
+            maturities[mat.id] = mat_content
+        else:
+            spec_id = '_' + row['specification.mdn_key']
+            spec_content = OrderedDict((
+                ('id', spec_id),
+                ('mdn_key', row['specification.mdn_key'])))
+            specifications[spec_id] = spec_content
+
+        # Load Section
+        section_id = row['section.id']
+        if section_id:
+            section = Section.objects.get(id=section_id)
+            feature_ids = [
+                str(f_id) for f_id in section.features.values_list(
+                    'id', flat=True)]
+            if main_feature_id not in feature_ids:
+                feature_ids.append(main_feature_id)
+            section_content = OrderedDict((
+                ('id', str(section_id)),
+                ('number', section.number),
+                ('name', section.name),
+                ('subpath', section.subpath),
+                ('note', section.note),
+                ('links', OrderedDict((
+                    ('specification', spec_id),
+                    ('features', feature_ids))))))
+        else:
+            section_id = str(spec_id) + '_' + row['section.subpath']
+            section_content = OrderedDict((
+                ('id', section_id),
+                ('number', OrderedDict()),
+                ('name', OrderedDict()),
+                ('subpath', OrderedDict()),
+                ('note', OrderedDict()),
+                ('links', OrderedDict((
+                    ('specification', spec_id),
+                    ('features', [main_feature_id]))))))
+        section_content['name']['en'] = row['section.name']
+        section_content['subpath']['en'] = row['section.subpath']
+        section_content['note']['en'] = row['section.note']
+        sections[section_id] = section_content
+        fp_data['features']['links']['sections'].append(str(section_id))
+
+    # Add linked data
+    fp_data['linked']['specifications'] = list(specifications.values())
+    fp_data['linked']['maturities'] = list(maturities.values())
+    fp_data['linked']['sections'] = list(sections.values())
+    languages = fp_data['features']['mdn_uri'].keys()
+    fp_data['meta']['compat_table']['languages'] = list(languages)
+    fp.data = fp_data
+
+    # Add issues
+    for err in chain(data['issues'], data['errors']):
+        if isinstance(err, tuple):
+            html = range_error_to_html(en_content.raw, *err)
+            fp.add_error(html, True)
+        else:
+            fp.add_error(err)
+
+    # Update status, issues
+    fp.status = fp.STATUS_PARSED
+    fp.save()

--- a/mdn/scrape.py
+++ b/mdn/scrape.py
@@ -1338,7 +1338,7 @@ def scrape_feature_page(fp):
                 feature_ids.append(main_feature_id)
             section_content = OrderedDict((
                 ('id', text_type(section_id)),
-                ('number', section.number),
+                ('number', section.number or None),
                 ('name', section.name),
                 ('subpath', section.subpath),
                 ('note', section.note),
@@ -1348,7 +1348,7 @@ def scrape_feature_page(fp):
             section_id = text_type(spec_id) + '_' + row['section.subpath']
             section_content = OrderedDict((
                 ('id', section_id),
-                ('number', OrderedDict()),
+                ('number', None),
                 ('name', OrderedDict()),
                 ('subpath', OrderedDict()),
                 ('note', OrderedDict()),
@@ -1393,7 +1393,7 @@ def scrape_feature_page(fp):
                     ('id', text_type(browser.id)),
                     ('slug', browser.slug),
                     ('name', browser.name),
-                    ('note', browser.note),
+                    ('note', browser.note or None),
                 ))
             browsers[b['id']] = browser_content
             tab['browsers'].append(browser_content['id'])
@@ -1457,7 +1457,7 @@ def scrape_feature_page(fp):
                 # New Version
                 version_content = OrderedDict((
                     ('id', v['id']),
-                    ('version', v['version']),
+                    ('version', v['version'] or None),
                     ('release_day', None),
                     ('retirement_day', None),
                     ('status', 'unknown'),
@@ -1470,7 +1470,7 @@ def scrape_feature_page(fp):
                 version = Version.objects.get(id=v['id'])
                 version_content = OrderedDict((
                     ('id', text_type(v['id'])),
-                    ('version', version.version),
+                    ('version', version.version or None),
                     ('release_day', date_to_iso(version.release_day)),
                     ('retirement_day', date_to_iso(version.retirement_day)),
                     ('status', version.status),

--- a/mdn/tasks.py
+++ b/mdn/tasks.py
@@ -1,0 +1,165 @@
+"""Asyncronous tasks for MDN scraping."""
+
+from json import dumps
+from traceback import format_exc
+
+from celery import shared_task
+import requests
+
+from .models import FeaturePage, TranslatedContent
+from .scrape import scrape_feature_page
+
+
+@shared_task(ignore_result=True)
+def start_crawl(featurepage_id):
+    """Start the calling process for an MDN page."""
+    fp = FeaturePage.objects.get(id=featurepage_id)
+    assert fp.status == fp.STATUS_STARTING, fp.status
+    meta = fp.meta()
+
+    # Determine next state / task
+    next_task = lambda: None
+    if meta.status == meta.STATUS_STARTING:
+        fp.status = fp.STATUS_META
+        next_task = lambda: fetch_meta.delay(fp.id)
+    elif meta.status == meta.STATUS_FETCHING:
+        fp.status = fp.STATUS_META
+    elif meta.status == meta.STATUS_FETCHED:
+        fp.status = fp.STATUS_PAGES
+        next_task = lambda: fetch_all_translations.delay(fp.id)
+    else:
+        assert meta.status == meta.STATUS_ERROR, meta.status
+        fp.status = fp.STATUS_ERROR
+        fp.add_error("Failed to download %s: %s" % (meta.url(), meta.raw))
+    fp.save()
+    next_task()
+
+
+@shared_task(ignore_result=True)
+def fetch_meta(featurepage_id):
+    """Fetch metadata for an MDN page."""
+    fp = FeaturePage.objects.get(id=featurepage_id)
+    assert fp.status == fp.STATUS_META, fp.status
+    meta = fp.meta()
+    assert meta.status == meta.STATUS_STARTING, meta.status
+
+    # Avoid double fetching
+    meta.status = meta.STATUS_FETCHING
+    meta.save(update_fields=['status'])
+
+    # Request and validate the metadata
+    url = meta.url()
+    r = requests.get(url)
+    if r.status_code != requests.codes.ok:
+        meta.raw = "Status %d, Content:\n%s" % (r.status_code, r.text)
+        meta.status = meta.STATUS_ERROR
+        next_task = r.raise_for_status
+    else:
+        try:
+            meta.raw = dumps(r.json())
+        except ValueError:
+            meta.raw = "Response is not JSON:\n" + r.text
+            meta.status = meta.STATUS_ERROR
+            next_task = r.json
+        else:
+            meta.status = meta.STATUS_FETCHED
+    meta.save()
+
+    # Determine next state / task
+    if meta.status == meta.STATUS_ERROR:
+        fp.status = fp.STATUS_ERROR
+        fp.add_error("Failed to download %s: %s" % (url, meta.raw))
+    else:
+        assert meta.status == meta.STATUS_FETCHED, meta.status
+        fp.status = fp.STATUS_PAGES
+        next_task = lambda: fetch_all_translations.delay(fp.id)
+    fp.save()
+    next_task()
+
+
+@shared_task(ignore_result=True)
+def fetch_all_translations(featurepage_id):
+    """Fetch all translations for an MDN page."""
+    fp = FeaturePage.objects.get(id=featurepage_id)
+    assert fp.status == fp.STATUS_PAGES, fp.status
+    translations = fp.translations()
+    assert translations, translations
+
+    # Gather / count by status
+    to_fetch = []
+    fetching = 0
+    errored = 0
+    for t in translations:
+        if t.status == t.STATUS_STARTING:
+            to_fetch.append(t)
+        elif t.status == t.STATUS_FETCHING:
+            fetching += 1
+        elif t.status == t.STATUS_ERROR:
+            fp.add_error("Failed to download %s: %s" % (t.url(), t.raw))
+            errored += 1
+        else:
+            assert t.status == t.STATUS_FETCHED, t.status
+
+    # Determine next status / task
+    if errored:
+        fp.status = fp.STATUS_ERROR
+        fp.save()
+    elif (not fetching) and (not to_fetch):
+        fp.status = fp.STATUS_PARSING
+        fp.save()
+        parse_page.delay(fp.id)
+    elif to_fetch:
+        for t in to_fetch:
+            fetch_translation.delay(fp.id, t.locale)
+
+
+@shared_task(ignore_result=True)
+def fetch_translation(featurepage_id, locale):
+    """Fetch a translations for an MDN page."""
+    fp = FeaturePage.objects.get(id=featurepage_id)
+    if fp.status in (fp.STATUS_PARSING, fp.STATUS_PARSED):
+        # Already fetched
+        t = TranslatedContent.objects.get(page=fp, locale=locale)
+        assert t.status == t.STATUS_FETCHED, t.status
+        return
+    assert fp.status == fp.STATUS_PAGES, fp.status
+    t = TranslatedContent.objects.get(page=fp, locale=locale)
+    assert t.status == t.STATUS_STARTING, t.status
+
+    # Avoid double fetching
+    t.status = t.STATUS_FETCHING
+    t.save(update_fields=['status'])
+
+    # Request the translation
+    r = requests.get(t.url() + "?raw")
+    t.raw = r.text
+    if r.status_code != requests.codes.ok:
+        t.status = t.STATUS_ERROR
+        t.raw = "Status %d, Content:\n%s" % (r.status_code, r.text)
+        next_task = r.raise_for_status
+    else:
+        t.status = t.STATUS_FETCHED
+        next_task = lambda: fetch_all_translations.delay(fp.id)
+    t.save()
+
+    # Determine next state / task
+    if t.status == t.STATUS_ERROR:
+        fp.status = fp.STATUS_ERROR
+        fp.add_error("Failed to download %s: %s" % (t.url(), t.raw))
+        fp.save()
+    next_task()
+
+
+@shared_task(ignore_result=True)
+def parse_page(featurepage_id):
+    fp = FeaturePage.objects.get(id=featurepage_id)
+    assert fp.status == fp.STATUS_PARSING, fp.status
+    try:
+        scrape_feature_page(fp)
+    except:
+        # Unexpected exceptions are added and re-raised
+        # Expected exceptions are handled by scrape_feature_page
+        fp.status = FeaturePage.STATUS_ERROR
+        fp.add_error(format_exc())
+        fp.save()
+        raise

--- a/mdn/templates/mdn/feature_page_detail.jinja2
+++ b/mdn/templates/mdn/feature_page_detail.jinja2
@@ -14,10 +14,10 @@
     <dd>{{object.id}}</dd>
   <dt>MDN URL</dt>
     <dd>
-      <a href="{{object.url}}">{{object.url}}</a>
+      <a id="mdn_link" href="{{object.url}}">{{object.url}}</a>
       <br/>
-      (<a href="{{object.url}}#Specifications">Specifications</a>,
-      <a href="{{object.url}}#Browser_compatibility">Browser Compatibility</a>)
+      (<a id="mdn_link_spec" href="{{object.url}}#Specifications">Specifications</a>,
+      <a id="mdn_link_compat" href="{{object.url}}#Browser_compatibility">Browser Compatibility</a>)
     </dd>
   <dt>Feature ID</dt>
     <dd><a href="/view_feature/{{object.feature_id}}">{{object.feature_id}}</a></td>
@@ -138,6 +138,8 @@ function load_tables(resources, lang) {
     }
     $("#mdn_link").attr("href", mdn_uri);
     $("#mdn_link").text(mdn_uri);
+    $("#mdn_link_spec").attr("href", mdn_uri + "#Specifications")
+    $("#mdn_link_compat").attr("href", mdn_uri + "#Browser_compatibility")
 
     pagination = resources.meta.compat_table.pagination["linked.features"];
     if (pagination && (pagination.next || pagination.previous)) {

--- a/mdn/templates/mdn/feature_page_detail.jinja2
+++ b/mdn/templates/mdn/feature_page_detail.jinja2
@@ -1,0 +1,182 @@
+{% extends "webplatformcompat/base.jinja2" %}
+
+{% block head_title %}Parse results for {{object.slug()}}{% endblock %}
+
+{% block body_title %}Parse results for {{object.slug()}}{% endblock %}
+
+{% block quick_nav %}
+<p><em>back to <a href="{{ url('feature_page_list') }}">page list</a></em></p>
+{% endblock %}
+
+{% block content %}
+<dl>
+  <dt>ID</dt>
+    <dd>{{object.id}}</dd>
+  <dt>MDN URL</dt>
+    <dd>
+      <a href="{{object.url}}">{{object.url}}</a>
+      <br/>
+      (<a href="{{object.url}}#Specifications">Specifications</a>,
+      <a href="{{object.url}}#Browser_compatibility">Browser Compatibility</a>)
+    </dd>
+  <dt>Feature ID</dt>
+    <dd><a href="/view_feature/{{object.feature_id}}">{{object.feature_id}}</a></td>
+  <dt>Status</dt>
+    <dd>{{object.get_status_display()}}</dd>
+  <dt>Last Modified</dt>
+    <dd>{{ object.same_since() }}</dd>
+  <dt>Issues</dt>
+    <dd>{% if object.has_issues %}
+      <ul>
+        {% for error in object.data['meta']['scrape']['errors'] %}
+        <li>{{ error | safe }}</li>
+        {% else %}
+        <li><em><code>.has_errors</code> is set, but no errors recorded</em></li>
+        {% endfor %}
+      </ul>{% else %}
+      <em>None detected</em>
+      {% endif %}
+    </dd>
+</dl>
+{% if request.user.is_staff %}
+<h3>Refresh Import</h3>
+<div>
+<form action="{{url('feature_page_reset', pk=object.pk)}}" method="post">
+{{ csrf() }}
+<input id="submit-reset" class="btn btn-primary" type="submit" value="Reset">
+<label for="submit-reset">Download MDN pages and reparse</label>
+</form>
+<br/>
+<form action="{{url('feature_page_reparse', pk=object.pk)}}" method="post">
+{{ csrf() }}
+<input id="submit-reparse" class="btn btn-primary" type="submit" value="Reparse">
+<label for="submit-reparse">Re-parse the cached MDN pages</label>
+</form>
+</div>
+<br/>
+{% endif %}
+
+{% if object.status == object.STATUS_PARSED %}
+<h1>Sample Presentation of {{object.slug()}}</h1>
+<h2>Specifications</h2>
+<div id="wpc_specifications">
+  <p><i>Loading...</i></p>
+</div>
+
+<h2>Browser compatibility</h2>
+<div id="wpc_tables">
+  <p><i>Loading...</i></p>
+</div>
+
+<h2>Languages</h2>
+<p>
+    The data may include translations of items such as feature names,
+    specification statuses, release notes URIs, etc.  Available languages:</p>
+<div id="wpc_languages">
+  <ul>
+    <li><i>Loading...</i></li>
+  </ul>
+</div>
+
+<h2>Raw Data</h2>
+<p>
+  This
+  <a href="{{url('feature_page_json', pk=object.pk)}}">raw JSON-API data</a>
+  resembles that returned from
+  <code>
+    <a id="wpc_uri" href="/api/v1/view_features/{{feature_id}}">
+      /api/v1/view_features/{{object.feature.id}}
+    </a>
+  </code>
+</p>
+
+<div id="wpc_data">
+  <p><i>Loading...</i></p>
+</div>
+{% else %}
+<p><em>
+    Parsed data and scraping issues will be available when the status is "Parsing Complete".
+</em></p>
+{% endif %}
+{% endblock content %}
+
+{% block body_js_extra %}
+<script>
+function load_tables(resources, lang) {
+    var spec_table, browser_tables, langs, pagination;
+
+    spec_table = WPC.generate_specification_table(resources, lang);
+    if (spec_table) {
+    $("#wpc_specifications").html(spec_table);
+    } else {
+    $("#wpc_specifications").html("<p><i>No specifications</i></p>");
+    }
+
+    browser_tables = WPC.generate_browser_tables(resources, lang);
+    if (browser_tables) {
+    $("#wpc_tables").html(browser_tables);
+    } else {
+    $("#wpc_tables").html("<p><i>No features</i></p>");
+    }
+
+    langs = "<ul>";
+    $.each(resources.meta.compat_table.languages, function(index, value) {
+        langs += (
+            "<li><a href=\"#\" onclick=\"load_tables(resources, '" +
+            value + "')\" >" + value + "</a>");
+        if (value === lang) {
+            langs += " (<strong>current</strong>)";
+        }
+        langs += "</li>";
+    });
+    langs += '</ul>';
+    $("#wpc_languages").html($(langs));
+
+    mdn_uri = WPC.trans_str(resources.data.mdn_uri, lang);
+    if (!mdn_uri) {
+        mdn_uri = "https://developer.mozilla.org/";
+    }
+    $("#mdn_link").attr("href", mdn_uri);
+    $("#mdn_link").text(mdn_uri);
+
+    pagination = resources.meta.compat_table.pagination["linked.features"];
+    if (pagination && (pagination.next || pagination.previous)) {
+        pageText = (
+            "<p id=\"wpc_pagination\">There are " + pagination.count +
+            " sub-features, which is too many to display on one page." +
+            " Go to the ");
+        if (pagination.next) {
+            pageText += ("<a href=\"#\" onclick=\"load_json('" +
+                pagination.next + "')\">next page</a>");
+        }
+        if (pagination.next && pagination.previous) {
+            pageText += " or the ";
+        }
+        if (pagination.previous) {
+            pageText += ("<a href=\"#\" onclick=\"load_json('" +
+                pagination.previous + "')\">previous page</a>");
+        }
+        pageText += ".</p>";
+        $("#wpc_pagination").html($(pageText));
+    }
+
+    return true;
+};
+
+function load_json(data) {
+    var resources, json_dump, title;
+    json_dump = $("<pre>").text(JSON.stringify(data, null, "  "));
+    $("#wpc_data").html(json_dump);
+    window.resources = resources = WPC.parse_resources(data);
+    load_tables(window.resources, "en");
+};
+
+data = {{ object.raw_data | default('null', True) | safe }};
+
+$( document ).ready(function () {
+    if (data) {
+        load_json(data);
+    }
+});
+</script>
+{% endblock body_js_extra %}

--- a/mdn/templates/mdn/feature_page_detail.jinja2
+++ b/mdn/templates/mdn/feature_page_detail.jinja2
@@ -37,9 +37,9 @@
       {% endif %}
     </dd>
 </dl>
-{% if can_refresh_mdn_import(request.user) %}
-<h3>Refresh Import</h3>
+<h3>Actions</h3>
 <div>
+{% if can_refresh_mdn_import(request.user) %}
 <form action="{{url('feature_page_reset', pk=object.pk)}}" method="post">
 {{ csrf() }}
 <input id="submit-reset" class="btn btn-primary" type="submit" value="Reset">
@@ -48,14 +48,27 @@
 <br/>
 {% endif %}
 {% if can_reparse_mdn_import(request.user) %}
-<form action="{{url('feature_page_reparse', pk=object.pk)}}" method="post">
+<form id="form-reparse" action="{{url('feature_page_reparse', pk=object.pk)}}" method="post">
 {{ csrf() }}
 <input id="submit-reparse" class="btn btn-primary" type="submit" value="Reparse">
 <label for="submit-reparse">Re-parse the cached MDN pages</label>
 </form>
+<br/>
+{% endif %}
+{% if can_commit_mdn_import(request.user) %}
+<form id="form-commit" class="hide"
+ action="{{url('viewfeatures-detail', pk=object.feature_id)}}" method="put">
+{{ csrf() }}
+<input id="submit-commit" class="btn btn-primary" type="submit" value="Commit">
+<label for="submit-commit">Commit data to the API</label>
+</form>
+<div id="commit-errors" class="hide">
+    <h4>Errors returned from API:</h4>
+    <pre id="pre-commit-errors"></pre>
 </div>
 <br/>
 {% endif %}
+</div>
 
 {% if object.status == object.STATUS_PARSED %}
 <h1>Sample Presentation of {{object.slug()}}</h1>
@@ -166,12 +179,38 @@ function load_tables(resources, lang) {
     return true;
 };
 
+function commit_json() {
+    var frm, ajaxSettings, jsonData;
+    frm = $("#form-commit");
+    csrf = $("input[name='csrfmiddlewaretoken']").val();
+    jsonData = JSON.stringify(data);
+    ajaxSettings = {
+        type: "PUT",
+        url: frm.attr("action"),
+        data: jsonData,
+        contentType: "application/vnd.api+json",
+        headers: {'X-CSRFToken': csrf},
+        success: function(data, textStatus, jqXHR) {
+            $("#form-reparse").submit();
+        },
+        error: function(jqXHR, textStatus, errorThrown) {
+            $("#pre-commit-errors").html(jqXHR.responseText);
+            $("#commit-errors").removeClass("hide");
+        }
+    }
+    $.ajax(ajaxSettings);
+    return false;
+};
+
 function load_json(data) {
     var resources, json_dump, title;
     json_dump = $("<pre>").text(JSON.stringify(data, null, "  "));
     $("#wpc_data").html(json_dump);
     window.resources = resources = WPC.parse_resources(data);
     load_tables(window.resources, "en");
+    if (data.meta.scrape.errors.length === 0) {
+        $("#form-commit").removeClass('hide').on('submit', commit_json);
+    }
 };
 
 data = {{ object.raw_data | default('null', True) | safe }};

--- a/mdn/templates/mdn/feature_page_detail.jinja2
+++ b/mdn/templates/mdn/feature_page_detail.jinja2
@@ -38,7 +38,7 @@
       {% endif %}
     </dd>
 </dl>
-{% if request.user.is_staff %}
+{% if can_refresh_mdn_import(request.user) %}
 <h3>Refresh Import</h3>
 <div>
 <form action="{{url('feature_page_reset', pk=object.pk)}}" method="post">

--- a/mdn/templates/mdn/feature_page_detail.jinja2
+++ b/mdn/templates/mdn/feature_page_detail.jinja2
@@ -1,7 +1,6 @@
 {% extends "webplatformcompat/base.jinja2" %}
 
 {% block head_title %}Parse results for {{object.slug()}}{% endblock %}
-
 {% block body_title %}Parse results for {{object.slug()}}{% endblock %}
 
 {% block quick_nav %}

--- a/mdn/templates/mdn/feature_page_detail.jinja2
+++ b/mdn/templates/mdn/feature_page_detail.jinja2
@@ -46,6 +46,8 @@
 <label for="submit-reset">Download MDN pages and reparse</label>
 </form>
 <br/>
+{% endif %}
+{% if can_reparse_mdn_import(request.user) %}
 <form action="{{url('feature_page_reparse', pk=object.pk)}}" method="post">
 {{ csrf() }}
 <input id="submit-reparse" class="btn btn-primary" type="submit" value="Reparse">

--- a/mdn/templates/mdn/feature_page_form.jinja2
+++ b/mdn/templates/mdn/feature_page_form.jinja2
@@ -1,12 +1,13 @@
 {% extends "webplatformcompat/base.jinja2" %}
+{% set method=method or "post" %}
 
 {% block head_title %}MDN Importer - {{action | default("Add MDN Page")}}{% endblock %}
 
 {% block body_title %}MDN Importer - {{action | default("Add MDN Page")}}{% endblock %}
 
 {% block content %}
-<form {% if action_url %}action="{{action_url}}"{% endif %} method="post">
-{{ csrf() }}
+<form {% if action_url %}action="{{action_url}}"{% endif %} method="{{method}}">
+{% if method != 'get'%}{{ csrf() }}{% endif %}
 {{ form.as_p() }}
 <input class="btn btn-primary" type="submit" value="{{action | default("Add MDN Page")}}">
 <a class="btn btn-default" href="{{back_url | default(url('feature_page_list'))}}">{{back | default("Back to List")}}</a>

--- a/mdn/templates/mdn/feature_page_form.jinja2
+++ b/mdn/templates/mdn/feature_page_form.jinja2
@@ -1,0 +1,15 @@
+{% extends "webplatformcompat/base.jinja2" %}
+
+{% block head_title %}MDN Importer - {{action | default("Add MDN Page")}}{% endblock %}
+
+{% block body_title %}MDN Importer - {{action | default("Add MDN Page")}}{% endblock %}
+
+{% block content %}
+<form {% if action_url %}action="{{action_url}}"{% endif %} method="post">
+{{ csrf() }}
+{{ form.as_p() }}
+<input class="btn btn-primary" type="submit" value="{{action | default("Add MDN Page")}}">
+<a class="btn btn-default" href="{{back_url | default(url('feature_page_list'))}}">{{back | default("Back to List")}}</a>
+</form>
+
+{% endblock content %}

--- a/mdn/templates/mdn/feature_page_list.jinja2
+++ b/mdn/templates/mdn/feature_page_list.jinja2
@@ -5,8 +5,7 @@
 {% block body_title %}MDN Importer{% endblock %}
 
 {% block content %}
-<form class="form-inline" action="{{url("feature_page_search")}}" method="POST">
-  {{ csrf() }}
+<form class="form-inline" action="{{url("feature_page_search")}}" method="GET">
   <div class="form-group">
     <label class="sr-only" for="id-url">MDN URL</label>
     <input type="url" class="form-control" id="id-url" name="url"

--- a/mdn/templates/mdn/feature_page_list.jinja2
+++ b/mdn/templates/mdn/feature_page_list.jinja2
@@ -14,6 +14,7 @@
   <input id="fp-search" class="btn btn-primary" type="submit" value="Search by URL">
 </form>
 {% if page_obj %}
+{{ pagination_control(page_obj, url('feature_page_list')) }}
 <table class="table table-condensed">
   <thead>
     <tr>
@@ -45,6 +46,7 @@
     {% endfor %}
   </tbody>
 </table>
+{{ pagination_control(page_obj, url('feature_page_list')) }}
 {% else %}
 <p><i>No pages imported yet.</i></p>
 {% endif %}

--- a/mdn/templates/mdn/feature_page_list.jinja2
+++ b/mdn/templates/mdn/feature_page_list.jinja2
@@ -51,7 +51,7 @@
 <p><i>No pages imported yet.</i></p>
 {% endif %}
 
-{% if request.user.is_staff %}
+{% if can_create_mdn_import(request.user) %}
 <a class="btn btn-primary" href="{{url('feature_page_create')}}">Import a new page</a>
 {% endif %}
 

--- a/mdn/templates/mdn/feature_page_list.jinja2
+++ b/mdn/templates/mdn/feature_page_list.jinja2
@@ -1,0 +1,57 @@
+{% extends "webplatformcompat/base.jinja2" %}
+
+{% block head_title %}MDN Importer{% endblock %}
+
+{% block body_title %}MDN Importer{% endblock %}
+
+{% block content %}
+<form class="form-inline" action="{{url("feature_page_search")}}" method="POST">
+  {{ csrf() }}
+  <div class="form-group">
+    <label class="sr-only" for="id-url">MDN URL</label>
+    <input type="url" class="form-control" id="id-url" name="url"
+     placeholder="https://developer.mozilla.org/en-US/docs/...">
+  </div>
+  <input id="fp-search" class="btn btn-primary" type="submit" value="Search by URL">
+</form>
+{% if page_obj %}
+<table class="table table-condensed">
+  <thead>
+    <tr>
+      <th>#</th>
+      <th>Feature ID</th>
+      <th>MDN Slug</th>
+      <th>Status</th>
+      <th>Has Issues?</th>
+    </tr>
+  </thead>
+  <tbody>
+    {% for page in page_obj.object_list %}
+    <tr>
+      <td><a href="{{ url('feature_page_detail', pk=page.id) }}">{{page.id}}</a></td>
+      <td>{{page.feature_id}}</td>
+      <td>{{page.slug()}}</td>
+      <td><a href="{{ url('feature_page_detail', pk=page.id) }}">{{page.get_status_display()}}</a></td>
+      <td>
+        <a href="{{ url('feature_page_detail', pk=page.id) }}">
+        {%- if page.status == page.STATUS_PARSED -%}
+          {%- if page.has_issues %}<strong>Yes</strong>{% else %}No{%endif -%}
+        {%- elif page.status == page.STATUS_ERROR %}
+          Scraping Failed
+        {%- else %}
+          <em>Still Processing</em>
+        {%- endif -%}
+      </td>
+    </tr>
+    {% endfor %}
+  </tbody>
+</table>
+{% else %}
+<p><i>No pages imported yet.</i></p>
+{% endif %}
+
+{% if request.user.is_staff %}
+<a class="btn btn-primary" href="{{url('feature_page_create')}}">Import a new page</a>
+{% endif %}
+
+{% endblock content %}

--- a/mdn/templates/mdn/feature_page_list.jinja2
+++ b/mdn/templates/mdn/feature_page_list.jinja2
@@ -1,8 +1,11 @@
 {% extends "webplatformcompat/base.jinja2" %}
 
 {% block head_title %}MDN Importer{% endblock %}
-
 {% block body_title %}MDN Importer{% endblock %}
+
+{% block quick_nav %}
+<p><em>back to <a href="{{ url('home') }}">home</a></em></p>
+{% endblock %}
 
 {% block content %}
 <form class="form-inline" action="{{url("feature_page_search")}}" method="GET">

--- a/mdn/tests/test_helpers.py
+++ b/mdn/tests/test_helpers.py
@@ -1,0 +1,120 @@
+# -*- coding: utf-8 -*-
+"""Tests for jingo/jinja2 helper functions and filters."""
+
+from __future__ import unicode_literals
+
+from django.core.paginator import Paginator
+
+from mdn.helpers import page_list, pagination_control
+from webplatformcompat.tests.base import TestCase as BaseTestCase
+
+
+class TestCase(BaseTestCase):
+    def page(self, number, total):
+        paginator = Paginator(range(total * 2), 2)
+        return paginator.page(number)
+
+
+class TestPageList(TestCase):
+    def test_empty(self):
+        page = self.page(1, 0)
+        self.assertEqual([1], page_list(page))
+
+    def test_two_pages(self):
+        page = self.page(1, 2)
+        self.assertEqual([1, 2], page_list(page))
+
+    def test_five_pages(self):
+        page = self.page(3, 5)
+        self.assertEqual([1, 2, 3, 4, 5], page_list(page))
+
+    def test_seven_pages(self):
+        page = self.page(2, 7)
+        self.assertEqual([1, 2, 3, 4, 5, 6, 7], page_list(page))
+
+    def test_1_of_8_pages(self):
+        page = self.page(1, 8)
+        self.assertEqual([1, 2, 3, 4, 5, None, 8], page_list(page))
+
+    def test_2_of_8_pages(self):
+        page = self.page(2, 8)
+        self.assertEqual([1, 2, 3, 4, 5, None, 8], page_list(page))
+
+    def test_3_of_8_pages(self):
+        page = self.page(3, 8)
+        self.assertEqual([1, 2, 3, 4, 5, None, 8], page_list(page))
+
+    def test_4_of_8_pages(self):
+        page = self.page(4, 8)
+        self.assertEqual([1, 2, 3, 4, 5, None, 8], page_list(page))
+
+    def test_5_of_8_pages(self):
+        page = self.page(5, 8)
+        self.assertEqual([1, None, 4, 5, 6, 7, 8], page_list(page))
+
+    def test_6_of_8_pages(self):
+        page = self.page(6, 8)
+        self.assertEqual([1, None, 4, 5, 6, 7, 8], page_list(page))
+
+    def test_7_of_8_pages(self):
+        page = self.page(7, 8)
+        self.assertEqual([1, None, 4, 5, 6, 7, 8], page_list(page))
+
+    def test_8_of_8_pages(self):
+        page = self.page(8, 8)
+        self.assertEqual([1, None, 4, 5, 6, 7, 8], page_list(page))
+
+    def test_5_of_9_pages(self):
+        page = self.page(5, 9)
+        self.assertEqual([1, None, 4, 5, 6, None, 9], page_list(page))
+
+
+class TestPagnationControl(TestCase):
+    def test_one_page(self):
+        page = self.page(1, 1)
+        out = pagination_control(None, page, '/test')
+        self.assertEqual("", out)
+
+    def test_first_page(self):
+        page = self.page(1, 3)
+        out = pagination_control(None, page, '/test')
+        expected_prev = (
+            '<li class="disabled"><span aria-hidden="true">&laquo;</span>'
+            '</li>')
+        expected_next = (
+            '<li><a href="/test?page=2" aria-label="Next">'
+            '<span aria-hidden="true">&raquo;</span></a></li>')
+        self.assertInHTML(expected_prev, out)
+        self.assertInHTML(expected_next, out)
+
+    def test_middle_page(self):
+        page = self.page(2, 3)
+        out = pagination_control(None, page, '/test')
+        expected_prev = (
+            '<li><a href="/test" aria-label="Previous">'
+            '<span aria-hidden="true">&laquo;</span></a></li>')
+        expected_next = (
+            '<li><a href="/test?page=3" aria-label="Next">'
+            '<span aria-hidden="true">&raquo;</span></a></li>')
+        self.assertInHTML(expected_prev, out)
+        self.assertInHTML(expected_next, out)
+
+    def test_last_page(self):
+        page = self.page(3, 3)
+        out = pagination_control(None, page, '/test')
+        expected_prev = (
+            '<li><a href="/test?page=2" aria-label="Previous">'
+            '<span aria-hidden="true">&laquo;</span></a></li>')
+        expected_next = (
+            '<li class="disabled"><span aria-hidden="true">&raquo;</span>'
+            '</li>')
+        self.assertInHTML(expected_prev, out)
+        self.assertInHTML(expected_next, out)
+
+    def test_deep_middle_page(self):
+        page = self.page(5, 9)
+        out = pagination_control(None, page, '/test')
+        expected_spacer = (
+            '<li class="disabled"><span aria-hidden="true">&hellip;</span>'
+            '</li>')
+        self.assertInHTML(expected_spacer, out)

--- a/mdn/tests/test_models.py
+++ b/mdn/tests/test_models.py
@@ -1,0 +1,215 @@
+# -*- coding: utf-8 -*-
+"""Tests for MDN importer models."""
+
+from __future__ import unicode_literals
+from json import dumps
+
+from django.core.exceptions import ValidationError
+from django.utils.six import text_type
+
+from mdn.models import (
+    validate_mdn_url, FeaturePage, PageMeta, TranslatedContent)
+from webplatformcompat.models import Feature
+from webplatformcompat.tests.base import TestCase
+
+
+class TestValidateMdnUrl(TestCase):
+    def setUp(self):
+        self.url = "https://developer.mozilla.org/en-US/docs/Web/CSS/float"
+
+    def test_OK(self):
+        validate_mdn_url(self.url)
+
+    def test_raw(self):
+        url = self.url + '?raw'
+        self.assertRaises(ValidationError, validate_mdn_url, url)
+
+    def test_json(self):
+        url = self.url + '$json'
+        self.assertRaises(ValidationError, validate_mdn_url, url)
+
+    def test_anchor(self):
+        url = self.url + '#Specifications'
+        self.assertRaises(ValidationError, validate_mdn_url, url)
+
+    def test_bad_domain(self):
+        url = "http://docs.webplatform.org/wiki/html/elements/ruby"
+        self.assertRaises(ValidationError, validate_mdn_url, url)
+
+
+class TestFeaturePageModel(TestCase):
+    def setUp(self):
+        self.feature = self.create(Feature, slug='web-css-float')
+        self.fp = FeaturePage.objects.create(
+            url="https://developer.mozilla.org/en-US/docs/Web/CSS/float",
+            feature=self.feature, status=FeaturePage.STATUS_META)
+        self.metadata = {
+            "locale": "en-US",
+            "url": "https://developer.mozilla.org/en-US/docs/Web/CSS/float",
+            "translations": [{
+                "locale": "de",
+                "url": "https://developer.mozilla.org/de/docs/Web/CSS/float",
+            }],
+        }
+
+    def test_domain(self):
+        self.assertEqual("https://developer.mozilla.org", self.fp.domain())
+
+    def test_str(self):
+        expected = "Fetching Metadata for Web/CSS/float"
+        self.assertEqual(expected, str(self.fp))
+
+    def test_meta_new(self):
+        meta = self.fp.meta()
+        self.assertEqual('/en-US/docs/Web/CSS/float$json', meta.path)
+        self.assertEqual(meta.STATUS_STARTING, meta.status)
+
+    def test_meta_existing(self):
+        pm = PageMeta.objects.create(page=self.fp, path='/foo/path')
+        meta = self.fp.meta()
+        self.assertEqual(pm, meta)
+
+    def test_translations_no_meta(self):
+        translations = self.fp.translations()
+        self.assertEqual(0, len(translations))
+
+    def test_translations_new(self):
+        PageMeta.objects.create(
+            page=self.fp, path='/foo/path', status=PageMeta.STATUS_FETCHED,
+            raw=dumps(self.metadata))
+        t1, t2 = self.fp.translations()
+        self.assertEqual('en-US', t1.locale)
+        self.assertEqual('de', t2.locale)
+
+    def setup_content(self):
+        PageMeta.objects.create(
+            page=self.fp, path='/foo/path', status=PageMeta.STATUS_FETCHED,
+            raw=dumps(self.metadata))
+        TranslatedContent.objects.create(
+            page=self.fp, locale='en', path='/foo/en/path',
+            status=PageMeta.STATUS_FETCHED, raw="Black, White, Yellow, Red")
+        TranslatedContent.objects.create(
+            page=self.fp, locale='de', path='/foo/de/path',
+            status=PageMeta.STATUS_ERROR, raw="Schwarz, Weiß, Gelb, Rot")
+
+    def test_reset(self):
+        self.setup_content()
+        self.fp.reset()
+        meta = self.fp.meta()
+        self.assertEqual(meta.status, PageMeta.STATUS_STARTING)
+        t_en = TranslatedContent.objects.get(page=self.fp, locale='en')
+        self.assertEqual(t_en.status, PageMeta.STATUS_STARTING)
+        t_de = TranslatedContent.objects.get(page=self.fp, locale='de')
+        self.assertEqual(t_de.status, PageMeta.STATUS_STARTING)
+
+    def test_reset_without_clear(self):
+        self.setup_content()
+        self.fp.reset(False)
+        meta = self.fp.meta()
+        self.assertEqual(meta.status, PageMeta.STATUS_STARTING)
+        t_en = TranslatedContent.objects.get(page=self.fp, locale='en')
+        self.assertEqual(t_en.status, PageMeta.STATUS_FETCHED)
+        t_de = TranslatedContent.objects.get(page=self.fp, locale='de')
+        self.assertEqual(t_de.status, PageMeta.STATUS_STARTING)
+
+    def test_get_data_existing(self):
+        self.fp.raw_data = '{"foo": "bar"}'
+        self.assertEqual({"foo": "bar"}, self.fp.data)
+
+    def test_get_data_none(self):
+        self.fp.raw_data = None
+        self.assertEqual(
+            ['features', 'linked', 'meta'],
+            list(self.fp.data.keys()))
+
+    def test_get_data_empty(self):
+        self.fp.raw_data = ''
+        self.assertEqual(
+            ['features', 'linked', 'meta'],
+            list(self.fp.data.keys()))
+
+    def test_add_error(self):
+        error = "This is an error"
+        self.fp.add_error(error)
+        self.assertEqual(
+            ['<pre>This is an error</pre>'],
+            self.fp.data['meta']['scrape']['errors'])
+
+    def test_add_error_safe(self):
+        error = "This is an error"
+        self.fp.add_error(error, True)
+        self.assertEqual(
+            ['This is an error'],
+            self.fp.data['meta']['scrape']['errors'])
+
+    def test_add_duplicate_error(self):
+        error = "Duplicate error"
+        self.fp.add_error(error)
+        self.fp.add_error(error)
+        self.assertEqual(
+            ['<pre>Duplicate error</pre>'],
+            self.fp.data['meta']['scrape']['errors'])
+
+
+class TestPageMetaModel(TestCase):
+    def setUp(self):
+        fp = FeaturePage(
+            url="https://developer.mozilla.org/en-US/docs/Web/CSS/display",
+            feature_id=666,
+            status=FeaturePage.STATUS_PARSED)
+        self.meta = PageMeta(page=fp, path="/de/docs/Web/CSS/display")
+
+    def test_str(self):
+        expected = u'/de/docs/Web/CSS/display retrieved 0\xa0minutes ago'
+        self.assertEqual(expected, text_type(self.meta))
+
+    def test_url(self):
+        expected = "https://developer.mozilla.org/de/docs/Web/CSS/display"
+        self.assertEqual(expected, self.meta.url())
+
+    def test_data_fetched(self):
+        data = {'foo': 'bar'}
+        self.meta.status = self.meta.STATUS_FETCHED
+        self.meta.raw = dumps(data)
+        self.assertEqual(data, self.meta.data())
+
+    def test_locale_paths_new(self):
+        self.assertEqual([], self.meta.locale_paths())
+
+    def test_locale_paths_fetched(self):
+        data = {
+            'locale': 'en-US',
+            'url': 'https://developer.mozilla.org/en-US/docs/Web/CSS/display',
+            'translations': [{
+                'locale': 'es',
+                'url': 'https://developer.mozilla.org/es/docs/Web/CSS/display',
+            }],
+        }
+        self.meta.status = self.meta.STATUS_FETCHED
+        self.meta.raw = dumps(data)
+        expected = [
+            ('en-US',
+             'https://developer.mozilla.org/en-US/docs/Web/CSS/display'),
+            ('es', 'https://developer.mozilla.org/es/docs/Web/CSS/display'),
+        ]
+        self.assertEqual(expected, self.meta.locale_paths())
+
+
+class TestTranslatedContentModel(TestCase):
+    def setUp(self):
+        fp = FeaturePage(
+            url="https://developer.mozilla.org/en-US/docs/Web/CSS/float",
+            feature_id=666,
+            status=FeaturePage.STATUS_PARSED)
+        self.c = TranslatedContent(
+            page=fp,
+            locale="de",
+            path="/de/docs/Web/CSS/float")
+
+    def test_str(self):
+        expected = u'/de/docs/Web/CSS/float retrieved 0\xa0minutes ago'
+        self.assertEqual(expected, text_type(self.c))
+
+    def test_url(self):
+        expected = "https://developer.mozilla.org/de/docs/Web/CSS/float"
+        self.assertEqual(expected, self.c.url())

--- a/mdn/tests/test_scrape.py
+++ b/mdn/tests/test_scrape.py
@@ -1,4 +1,5 @@
 """Test mdn.scrape."""
+# vim: set fileencoding=utf-8 :
 from __future__ import unicode_literals
 from json import dumps
 
@@ -6,8 +7,10 @@ from parsimonious.grammar import Grammar
 
 from mdn.models import FeaturePage, TranslatedContent
 from mdn.scrape import (
-    page_grammar, range_error_to_html, scrape_page, scrape_feature_page)
-from webplatformcompat.models import Feature, Maturity, Section, Specification
+    end_of_line, page_grammar, range_error_to_html, scrape_page,
+    scrape_feature_page)
+from webplatformcompat.models import (
+    Browser, Feature, Maturity, Section, Specification)
 from webplatformcompat.tests.base import TestCase
 
 
@@ -79,17 +82,67 @@ class ScrapeTestCase(TestCase):
 </table>
 """
 
+    # From https://developer.mozilla.org/en-US/docs/Web/CSS/float?raw
+    simple_compat_section = """\
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+<div>
+ {{CompatibilityTable}}</div>
+<div id="compat-desktop">
+ <table class="compat-table">
+  <tbody>
+   <tr>
+    <th>Feature</th>
+    <th>Chrome</th>
+    <th>Firefox (Gecko)</th>
+    <th>Internet Explorer</th>
+    <th>Opera</th>
+    <th>Safari</th>
+   </tr>
+   <tr>
+    <td>Basic support</td>
+    <td>1.0</td>
+    <td>{{CompatGeckoDesktop("1")}}</td>
+    <td>4.0</td>
+    <td>7.0</td>
+    <td>1.0</td>
+   </tr>
+  </tbody>
+ </table>
+</div>
+<div id="compat-mobile">
+ <table class="compat-table">
+  <tbody>
+   <tr>
+    <th>Feature</th>
+    <th>Android</th>
+    <th>Firefox Mobile (Gecko)</th>
+    <th>IE Mobile</th>
+    <th>Opera Mobile</th>
+    <th>Safari Mobile</th>
+   </tr>
+   <tr>
+    <td>Basic support</td>
+    <td>1.0</td>
+    <td>{{CompatGeckoMobile("1")}}</td>
+    <td>6.0</td>
+    <td>6.0</td>
+    <td>1.0</td>
+   </tr>
+  </tbody>
+ </table>
+</div>
+"""
+
     simple_see_also = """\
 <h2 id="See_also">See also</h2>
 <ul>
  <li>{{CSS_Reference:Position}}</li>
  <li><a href="/en-US/docs/Web/CSS/block_formatting_context">\
 Block formatting context</a></li>
-</ul>
-"""
+</ul>"""
     simple_page = (
         simple_prefix + simple_other_section + simple_spec_section +
-        simple_see_also)
+        simple_compat_section + simple_see_also)
 
     def add_spec_models(self):
         self.maturity = self.create(
@@ -103,22 +156,84 @@ Block formatting context</a></li>
             Section, specification=self.spec, name='{"en": "background-size"}',
             subpath='{"en": "#the-background-size"}')
 
+    def add_compat_models(self):
+        browsers = (
+            ('Chrome', 'chrome'),
+            ('Firefox', 'firefox'),
+            ('Internet Explorer', 'ie'),
+            ('Opera', 'opera'),
+            ('Safari', 'safari'),
+            ('Android', 'android'),
+            ('Firefox Mobile', 'firefox-mobile'),
+            ('IE Mobile', 'ie-mobile'),
+            ('Opera Mobile', 'opera-mobile'),
+            ('Safari Mobile', 'safari-mobile'),
+        )
+        self.browsers = dict()
+        for name, slug in browsers:
+            self.browsers[slug] = self.create(
+                Browser, slug=slug, name={"en": name})
+
+        self.features = dict()
+        self.features['web'] = self.create(
+            Feature, slug='web', name={"en": "Web"})
+        self.features['web-css'] = self.create(
+            Feature, slug='web-css', name={"en": "CSS"},
+            parent=self.features['web'])
+        self.features['web-css-background-size'] = self.create(
+            Feature, slug='web-css-background-size',
+            name={"zxx": "background-size"})
+
+    def add_models(self):
+        self.add_spec_models()
+        self.add_compat_models()
+
+
+class TestEndOfLine(ScrapeTestCase):
+    def test_middle_of_text(self):
+        expected_eol = self.simple_page.index('\n', 30)
+        end = end_of_line(self.simple_page, expected_eol - 2)
+        self.assertEqual(expected_eol, end)
+
+    def test_end_of_text(self):
+        end = end_of_line(self.simple_page, len(self.simple_page) - 2)
+        self.assertEqual(len(self.simple_page), end)
+
 
 class TestScrape(ScrapeTestCase):
+
+    def assertScrape(self, page, expected):
+        """Specialize assertion for scraping"""
+        actual = scrape_page(page)
+        exp_issues = expected.pop('issues')
+        act_issues = actual.pop('issues')
+        exp_errors = expected.pop('errors')
+        act_errors = actual.pop('errors')
+        self.assertDataEqual(expected, actual)
+        self.assertEqual(len(exp_issues), len(act_issues), act_issues)
+        self.assertEqual(len(exp_errors), len(act_errors), act_errors)
+        for exp_issue, act_issue in zip(exp_issues, act_issues):
+            self.assertEqual(
+                exp_issue, act_issue, range_error_to_html(page, *act_issue))
+        for exp_error, act_error in zip(exp_errors, act_errors):
+            self.assertEqual(
+                exp_error, act_error, range_error_to_html(page, *act_error))
+
     def test_empty(self):
         out = scrape_page("")
         expected = {
             'locale': 'en',
             'specs': [],
+            'compat': [],
             'issues': [],
             'errors': ["No <h2> found in page"],
         }
-        self.assertEqual(out, expected)
+        self.assertDataEqual(out, expected)
 
     def test_spec_only(self):
         """Test with a only a Specification section."""
-        out = scrape_page(self.simple_spec_section)
         expected = {
+            'locale': 'en',
             'specs': [{
                 'specification.mdn_key': 'CSS3 Backgrounds',
                 'specification.id': None,
@@ -127,18 +242,18 @@ class TestScrape(ScrapeTestCase):
                 'section.note': '',
                 'section.id': None,
             }],
-            'locale': 'en',
+            'compat': [],
             'issues': [],
             'errors': [
                 (251, 335, 'Unknown Specification "CSS3 Backgrounds"'),
             ]
         }
-        self.assertEqual(expected, out)
+        self.assertScrape(self.simple_spec_section, expected)
 
-    def test_full_page(self):
+    def test_simple_page(self):
         """Test with a more complete but simple page."""
-        out = scrape_page(self.simple_page)
         expected = {
+            'locale': 'en',
             'specs': [{
                 'specification.mdn_key': 'CSS3 Backgrounds',
                 'specification.id': None,
@@ -147,39 +262,215 @@ class TestScrape(ScrapeTestCase):
                 'section.note': '',
                 'section.id': None,
             }],
-            'locale': 'en',
+            'compat': [{
+                'name': 'desktop',
+                'browsers': [
+                    {
+                        'name': 'Chrome',
+                        'id': '_Chrome',
+                    }, {
+                        'name': 'Firefox (Gecko)',
+                        'id': '_Firefox (Gecko)',
+                    }, {
+                        'name': 'Internet Explorer',
+                        'id': '_Internet Explorer',
+                    }, {
+                        'name': 'Opera',
+                        'id': '_Opera',
+                    }, {
+                        'name': 'Safari',
+                        'id': '_Safari',
+                    }],
+                'features': [
+                    {
+                        'name': 'Basic support',
+                        'id': '_Basic support',
+                        'experimental': False,
+                        'standardized': True,
+                        'stable': True,
+                        'obsolete': False,
+                    }],
+                'supports': [],
+            }, {
+                'name': 'mobile',
+                'browsers': [
+                    {
+                        'name': 'Android',
+                        'id': '_Android',
+                    }, {
+                        'name': 'Firefox Mobile (Gecko)',
+                        'id': '_Firefox Mobile (Gecko)',
+                    }, {
+                        'name': 'IE Mobile',
+                        'id': '_IE Mobile',
+                    }, {
+                        'name': 'Opera Mobile',
+                        'id': '_Opera Mobile',
+                    }, {
+                        'name': 'Safari Mobile',
+                        'id': '_Safari Mobile',
+                    }],
+                'features': [
+                    {
+                        'name': 'Basic support',
+                        'id': '_Basic support',
+                        'experimental': False,
+                        'standardized': True,
+                        'stable': True,
+                        'obsolete': False,
+                    }],
+                'supports': [],
+            }],
             'issues': [],
             'errors': [
                 (902, 986, 'Unknown Specification "CSS3 Backgrounds"'),
+                (1262, 1282, u'Unknown Browser "Chrome"'),
+                (1282, 1311, u'Unknown Browser "Firefox (Gecko)"'),
+                (1311, 1342, u'Unknown Browser "Internet Explorer"'),
+                (1342, 1361, u'Unknown Browser "Opera"'),
+                (1361, 1380, u'Unknown Browser "Safari"'),
+                (1665, 1686, u'Unknown Browser "Android"'),
+                (1686, 1722, u'Unknown Browser "Firefox Mobile (Gecko)"'),
+                (1722, 1745, u'Unknown Browser "IE Mobile"'),
+                (1745, 1771, u'Unknown Browser "Opera Mobile"'),
+                (1771, 1797, u'Unknown Browser "Safari Mobile"'),
             ]
         }
-        self.assertEqual(expected, out)
+        self.assertScrape(self.simple_page, expected)
+
+    def test_simple_page_with_data(self):
+        """Test with a simple page and data."""
+        self.add_models()
+        expected = {
+            'locale': 'en',
+            'specs': [{
+                'specification.mdn_key': 'CSS3 Backgrounds',
+                'specification.id': self.spec.id,
+                'section.subpath': '#the-background-size',
+                'section.name': 'background-size',
+                'section.note': '',
+                'section.id': self.section.id,
+            }],
+            'compat': [{
+                'name': 'desktop',
+                'browsers': [
+                    {
+                        'name': 'Chrome',
+                        'id': self.browsers['chrome'].pk,
+                    }, {
+                        'name': 'Firefox (Gecko)',
+                        'id': self.browsers['firefox'].pk,
+                    }, {
+                        'name': 'Internet Explorer',
+                        'id': self.browsers['ie'].pk,
+                    }, {
+                        'name': 'Opera',
+                        'id': self.browsers['opera'].pk,
+                    }, {
+                        'name': 'Safari',
+                        'id': self.browsers['safari'].pk,
+                    }],
+                'features': [
+                    {
+                        'name': 'Basic support',
+                        'id': '_Basic support',
+                        'experimental': False,
+                        'standardized': True,
+                        'stable': True,
+                        'obsolete': False,
+                    }],
+                'supports': [],
+            }, {
+                'name': 'mobile',
+                'browsers': [
+                    {
+                        'name': 'Android',
+                        'id': self.browsers['android'].pk,
+                    }, {
+                        'name': 'Firefox Mobile (Gecko)',
+                        'id': self.browsers['firefox-mobile'].pk,
+                    }, {
+                        'name': 'IE Mobile',
+                        'id': self.browsers['ie-mobile'].pk,
+                    }, {
+                        'name': 'Opera Mobile',
+                        'id': self.browsers['opera-mobile'].pk,
+                    }, {
+                        'name': 'Safari Mobile',
+                        'id': self.browsers['safari-mobile'].pk,
+                    }],
+                'features': [
+                    {
+                        'name': 'Basic support',
+                        'id': '_Basic support',
+                        'experimental': False,
+                        'standardized': True,
+                        'stable': True,
+                        'obsolete': False,
+                    }],
+                'supports': [],
+            }],
+            'issues': [],
+            'errors': [],
+        }
+        self.assertScrape(self.simple_page, expected)
 
     def test_parse_error(self):
         page = self.simple_page.replace("</h2>", "</h3")
-        out = scrape_page(page)
         expected = {
             'locale': 'en',
             'specs': [],
+            'compat': [],
             'issues': [],
             'errors': [
-                (40, 52,
-                 'Rule "attr" failed to match.  Rule definition:',
-                 'attr = _ ident _ equals _ qtext _')]
+                (24, 52,
+                 'Unable to finish parsing MDN page, starting at this'
+                 ' position.')
+            ]
         }
-        self.assertEqual(expected, out)
+        self.assertScrape(page, expected)
+
+    def test_with_issues(self):
+        h2_fmt = '<h2 id="{0}" name="{0}">Specifications</h2>'
+        h2_good = h2_fmt.format('Specifications')
+        h2_bad = h2_fmt.format('Browser_Compatibility')
+        self.assertTrue(h2_good in self.simple_spec_section)
+        page = self.simple_spec_section.replace(h2_good, h2_bad)
+
+        expected = {
+            'locale': 'en',
+            'specs': [{
+                'specification.mdn_key': 'CSS3 Backgrounds',
+                'specification.id': None,
+                'section.subpath': '#the-background-size',
+                'section.name': 'background-size',
+                'section.note': '',
+                'section.id': None,
+            }],
+            'compat': [],
+            'issues': [
+                (0, 79,
+                 'In Specifications section, expected <h2 id="Specifications">'
+                 ', actual id="Browser_Compatibility"'),
+                (0, 79,
+                 'In Specifications section, expected <h2'
+                 ' name="Specifications"> or no name attribute,'
+                 ' actual name="Browser_Compatibility"'),
+            ],
+            'errors': [
+                (265, 349, 'Unknown Specification "CSS3 Backgrounds"'),
+            ],
+        }
+        self.assertScrape(page, expected)
 
 
 class TestScrapeFeaturePage(ScrapeTestCase):
     def setUp(self):
-        web = self.create(Feature, slug='web')
-        css = self.create(Feature, parent=web, slug='web-css')
-        self.background_size = self.create(
-            Feature, parent=css, slug='web-css-background')
+        self.add_models()
         url = ("https://developer.mozilla.org/en-US/docs/Web/CSS/"
                "background-size")
         self.page = FeaturePage.objects.create(
-            url=url, feature=self.background_size,
+            url=url, feature=self.features['web-css-background-size'],
             status=FeaturePage.STATUS_PARSING)
         meta = self.page.meta()
         meta.raw = dumps({
@@ -201,22 +492,23 @@ class TestScrapeFeaturePage(ScrapeTestCase):
         scrape_feature_page(self.page)
         fp = FeaturePage.objects.get(id=self.page.id)
         self.assertEqual(fp.STATUS_PARSED, fp.status)
-        self.assertTrue(fp.has_issues)
-        section_ids = ["_CSS3 Backgrounds_#the-background-size"]
-        self.assertEqual(section_ids, fp.data['features']['links']['sections'])
-        self.assertEqual('_unknown', fp.data['linked']['maturities'][0]['id'])
-
-    def test_success_with_spec_data(self):
-        self.add_spec_models()
-        scrape_feature_page(self.page)
-        fp = FeaturePage.objects.get(id=self.page.id)
-        self.assertEqual(fp.STATUS_PARSED, fp.status)
+        self.assertEqual([], fp.data['meta']['scrape']['errors'])
         self.assertFalse(fp.has_issues)
         section_ids = [str(self.section.id)]
         self.assertEqual(section_ids, fp.data['features']['links']['sections'])
 
+    def test_with_specification_mismatch(self):
+        self.spec.mdn_key = 'CSS3_Backgrounds'
+        self.spec.save()
+        scrape_feature_page(self.page)
+        fp = FeaturePage.objects.get(id=self.page.id)
+        self.assertEqual(fp.STATUS_PARSED, fp.status)
+        self.assertTrue(fp.has_issues)
+        self.assertEqual(
+            ["_CSS3 Backgrounds_#the-background-size"],
+            fp.data['features']['links']['sections'])
+
     def test_with_section_mismatch(self):
-        self.add_spec_models()
         self.section.subpath['en'] = '#the-other-background-size'
         self.section.save()
         scrape_feature_page(self.page)
@@ -227,8 +519,7 @@ class TestScrapeFeaturePage(ScrapeTestCase):
         self.assertEqual(section_ids, fp.data['features']['links']['sections'])
 
     def test_with_section_already_associated(self):
-        self.add_spec_models()
-        self.background_size.sections.add(self.section)
+        self.page.feature.sections.add(self.section)
         scrape_feature_page(self.page)
         fp = FeaturePage.objects.get(id=self.page.id)
         self.assertEqual(fp.STATUS_PARSED, fp.status)
@@ -236,25 +527,39 @@ class TestScrapeFeaturePage(ScrapeTestCase):
         section_ids = [str(self.section.id)]
         self.assertEqual(section_ids, fp.data['features']['links']['sections'])
 
-    def test_with_issues(self):
-        self.add_spec_models()
+    def test_with_browser_mismatch(self):
+        good_name = '<th>Chrome</th>'
+        bad_name = '<th>Chromium</th>'
         en_content = TranslatedContent.objects.get(
             page=self.page, locale='en-US')
-
-        h2_fmt = '<h2 id="{0}" name="{0}">Specifications</h2>'
-        h2_good = h2_fmt.format('Specifications')
-        h2_bad = h2_fmt.format('Browser_Compatibility')
-        self.assertTrue(h2_good in en_content.raw)
-        en_content.raw = en_content.raw.replace(h2_good, h2_bad)
+        self.assertEqual(1, en_content.raw.count(good_name))
+        en_content.raw = en_content.raw.replace(good_name, bad_name)
         en_content.save()
 
         scrape_feature_page(self.page)
         fp = FeaturePage.objects.get(id=self.page.id)
         self.assertEqual(fp.STATUS_PARSED, fp.status)
         self.assertTrue(fp.has_issues)
+        self.assertEqual(1, len(fp.data['meta']['scrape']['errors']))
+        err = fp.data['meta']['scrape']['errors'][0]
+        expected = '<div><p>Unknown Browser &quot;Chromium&quot;</p>'
+        self.assertTrue(err.startswith(expected))
+        desktop_browsers = fp.data['meta']['compat_table']['tabs'][0]
+        self.assertEqual('Desktop', desktop_browsers['name']['en'])
+        self.assertEqual('_Chromium', desktop_browsers['browsers'][0])
+
+    def test_with_existing_feature(self):
+        basic = self.create(
+            Feature, slug=self.page.feature.slug + '-basic-support',
+            name={'en': 'Basic support'}, parent=self.page.feature)
+        scrape_feature_page(self.page)
+        fp = FeaturePage.objects.get(id=self.page.id)
+        self.assertEqual(fp.STATUS_PARSED, fp.status)
+        self.assertFalse(fp.has_issues)
+        supports = fp.data['meta']['compat_table']['supports']
+        self.assertTrue(str(basic.id) in supports)
 
     def test_scrape_almost_empty_page(self):
-        self.add_spec_models()
         en_content = TranslatedContent.objects.get(
             page=self.page, locale='en-US')
         en_content.raw = "<h1>nothing here</h1>"

--- a/mdn/tests/test_scrape.py
+++ b/mdn/tests/test_scrape.py
@@ -875,6 +875,13 @@ class TestPageVisitor(ScrapeTestCase):
             expected_errors=[
                 (4, 17, 'Unknown support text "Removed in 32"')])
 
+    def test_compat_row_cell_support_prefix_plus_footnote(self):
+        self.assert_compat_row_cell_support(
+            '18{{property_prefix("-webkit")}} [1]',
+            [{'version': '18.0'}],
+            [{'support': 'partial', 'prefix': '-webkit',
+              'footnote_id': ('1', 37, 40)}])
+
     def test_complex_footnotes_empty(self):
         text = "\n"
         parsed = self.grammar['compat_footnotes'].parse(text)
@@ -1251,12 +1258,12 @@ class TestScrape(ScrapeTestCase):
                     {'id': bs_id % self.versions[('chrome', '1.0')].pk,
                      'feature': '_basic support',
                      'version': self.versions[('chrome', '1.0')].pk,
-                     'support': 'yes', 'prefix': '-webkit',
+                     'support': 'partial', 'prefix': '-webkit',
                      'footnote_id': ('2', 1525, 1528), 'footnote': fn_2},
                     {'id': bs_id % self.versions[('firefox', '3.6')].pk,
                      'feature': '_basic support',
                      'version': self.versions[('firefox', '3.6')].pk,
-                     'support': 'yes', 'prefix': '-moz',
+                     'support': 'partial', 'prefix': '-moz',
                      'footnote_id': ('4', 1601, 1604), 'footnote': fn_4},
                     {'id': bs_id % self.versions[('ie', '9.0')].pk,
                      'feature': '_basic support',

--- a/mdn/tests/test_scrape.py
+++ b/mdn/tests/test_scrape.py
@@ -205,6 +205,8 @@ class TestEndOfLine(ScrapeTestCase):
 
 
 class TestScrape(ScrapeTestCase):
+    longMessage = True
+
     def setUp(self):
         self.add_compat_features()
 
@@ -332,16 +334,16 @@ class TestScrape(ScrapeTestCase):
             'issues': [],
             'errors': [
                 (902, 986, 'Unknown Specification "CSS3 Backgrounds"'),
-                (1262, 1282, u'Unknown Browser "Chrome"'),
-                (1282, 1311, u'Unknown Browser "Firefox (Gecko)"'),
-                (1311, 1342, u'Unknown Browser "Internet Explorer"'),
-                (1342, 1361, u'Unknown Browser "Opera"'),
-                (1361, 1380, u'Unknown Browser "Safari"'),
-                (1665, 1686, u'Unknown Browser "Android"'),
-                (1686, 1722, u'Unknown Browser "Firefox Mobile (Gecko)"'),
-                (1722, 1745, u'Unknown Browser "IE Mobile"'),
-                (1745, 1771, u'Unknown Browser "Opera Mobile"'),
-                (1771, 1797, u'Unknown Browser "Safari Mobile"'),
+                (1266, 1272, 'Unknown Browser "Chrome"'),
+                (1286, 1301, 'Unknown Browser "Firefox (Gecko)"'),
+                (1315, 1332, 'Unknown Browser "Internet Explorer"'),
+                (1346, 1351, 'Unknown Browser "Opera"'),
+                (1365, 1371, 'Unknown Browser "Safari"'),
+                (1669, 1676, 'Unknown Browser "Android"'),
+                (1690, 1712, 'Unknown Browser "Firefox Mobile (Gecko)"'),
+                (1726, 1735, 'Unknown Browser "IE Mobile"'),
+                (1749, 1761, 'Unknown Browser "Opera Mobile"'),
+                (1775, 1788, 'Unknown Browser "Safari Mobile"'),
             ]
         }
         self.assertScrape(self.simple_page, expected)

--- a/mdn/tests/test_scrape.py
+++ b/mdn/tests/test_scrape.py
@@ -204,6 +204,7 @@ class TestScrapeFeaturePage(ScrapeTestCase):
         self.assertTrue(fp.has_issues)
         section_ids = ["_CSS3 Backgrounds_#the-background-size"]
         self.assertEqual(section_ids, fp.data['features']['links']['sections'])
+        self.assertEqual('_unknown', fp.data['linked']['maturities'][0]['id'])
 
     def test_success_with_spec_data(self):
         self.add_spec_models()

--- a/mdn/tests/test_scrape.py
+++ b/mdn/tests/test_scrape.py
@@ -1,5 +1,5 @@
 """Test mdn.scrape."""
-# vim: set fileencoding=utf-8 :
+# -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 from json import dumps
 
@@ -132,6 +132,127 @@ class ScrapeTestCase(TestCase):
  </table>
 </div>
 """
+    # From Web/CSS/background-size?raw
+    # colspan="3" on the Safari column
+    # rowspan="2" on Basic Support row
+    # footnotes with a <pre> section
+    complex_compat_section = """\
+<h2 id="Browser_compatibility" name="Browser_compatibility">\
+Browser compatibility</h2>
+<div>
+ {{CompatibilityTable}}</div>
+<div id="compat-desktop">
+ <table class="compat-table">
+  <tbody>
+   <tr>
+    <th>Feature</th>
+    <th>Chrome</th>
+    <th>Firefox (Gecko)</th>
+    <th>Internet Explorer</th>
+    <th>Opera</th>
+    <th colspan="3">Safari (WebKit)</th>
+   </tr>
+   <tr>
+    <td rowspan="2">Basic support</td>
+    <td>1.0{{property_prefix("-webkit")}} [2]</td>
+    <td>{{CompatGeckoDesktop("1.9.2")}}{{property_prefix("-moz")}} [4]</td>
+    <td rowspan="2">9.0 [5]</td>
+    <td>9.5{{property_prefix("-o")}}<br>
+     with some bugs [1]</td>
+    <td>3.0 (522){{property_prefix("-webkit")}}<br>
+     but from an older CSS3 draft [2]</td>
+   </tr>
+   <tr>
+    <td>3.0</td>
+    <td>{{CompatGeckoDesktop("2.0")}}</td>
+    <td>10.0</td>
+    <td>4.1 (532)</td>
+   </tr>
+   <tr>
+    <td>Support for<br>
+     <code>contain</code> and <code>cover</code></td>
+    <td>3.0</td>
+    <td>{{CompatGeckoDesktop("1.9.2")}}</td>
+    <td>9.0 [5]</td>
+    <td>10.0</td>
+    <td colspan="3">4.1 (532)</td>
+   </tr>
+   <tr>
+    <td>Support for SVG backgrounds</td>
+    <td>{{CompatUnknown}}</td>
+    <td>{{CompatGeckoDesktop("8.0")}}</td>
+    <td>{{CompatUnknown}}</td>
+    <td>{{CompatUnknown}}</td>
+    <td colspan="3">{{CompatUnknown}}</td>
+   </tr>
+  </tbody>
+ </table>
+</div>
+<div id="compat-mobile">
+ <table class="compat-table">
+  <tbody>
+   <tr>
+    <th>Feature</th>
+    <th>Android</th>
+    <th>Firefox Mobile (Gecko)</th>
+    <th>Windows Phone</th>
+    <th>Opera Mobile</th>
+    <th>Safari Mobile</th>
+   </tr>
+   <tr>
+    <td>Basic support</td>
+    <td>{{CompatVersionUnknown}}{{property_prefix("-webkit")}}<br>
+     2.3</td>
+    <td>1.0{{property_prefix("-moz")}}<br>
+     4.0</td>
+    <td>{{CompatUnknown}}</td>
+    <td>{{CompatUnknown}}</td>
+    <td>5.1 (maybe earlier)</td>
+   </tr>
+   <tr>
+    <td>Support for SVG backgrounds</td>
+    <td>{{CompatUnknown}}</td>
+    <td>{{CompatGeckoMobile("8.0")}}</td>
+    <td>{{CompatUnknown}}</td>
+    <td>{{CompatUnknown}}</td>
+    <td>{{CompatUnknown}}</td>
+   </tr>
+  </tbody>
+ </table>
+</div>
+"""
+    complex_compat_footnotes = """\
+<p>[1] Opera 9.5's computation of the background positioning area is incorrect\
+ for fixed backgrounds.  Opera 9.5 also interprets the two-value form as a\
+ horizontal scaling factor and, from appearances, a vertical <em>clipping</em>\
+ dimension. This has been fixed in Opera 10.</p>
+<p>[2] WebKit-based browsers originally implemented an older draft of\
+ CSS3<code> background-size </code>in which an omitted second value is treated\
+ as <em>duplicating</em> the first value; this draft does not include\
+ the<code> contain </code>or<code> cover </code>keywords.</p>
+<p>[3] Konqueror 3.5.4 supports<code> -khtml-background-size</code>.</p>
+<p>[4] While this property is new in Gecko 1.9.2 (Firefox 3.6), it is possible\
+ to stretch a image fully over the background in Firefox 3.5 by using\
+ {{cssxref("-moz-border-image")}}.</p>
+<pre class="brush:css">.foo {
+  background-image: url(bg-image.png);
+
+  -webkit-background-size: 100% 100%;           /* Safari 3.0 */
+     -moz-background-size: 100% 100%;           /* Gecko 1.9.2 (Firefox 3.6) */
+       -o-background-size: 100% 100%;           /* Opera 9.5 */
+          background-size: 100% 100%;           /* Gecko 2.0 (Firefox 4.0) and\
+ other CSS3-compliant browsers */
+
+  -moz-border-image: url(bg-image.png) 0;    /* Gecko 1.9.1 (Firefox 3.5) */
+}</pre>
+<p>[5] Though Internet Explorer 8 doesn't support the\
+ <code>background-size</code> property, it is possible to emulate some of its\
+ functionality using the non-standard <code>-ms-filter</code> function:</p>
+<pre class="brush:css">-ms-filter:\
+ "progid:DXImageTransform.Microsoft.AlphaImageLoader(\
+src='path_relative_to_the_HTML_file', sizingMethod='scale')";</pre>
+<p>This simulates the value <code>cover</code>.</p>
+"""
 
     simple_see_also = """\
 <h2 id="See_also">See also</h2>
@@ -143,6 +264,9 @@ Block formatting context</a></li>
     simple_page = (
         simple_prefix + simple_other_section + simple_spec_section +
         simple_compat_section + simple_see_also)
+    complex_page = (
+        simple_prefix + simple_other_section + simple_spec_section +
+        complex_compat_section + complex_compat_footnotes + simple_see_also)
 
     def add_spec_models(self):
         self.maturity = self.create(
@@ -233,6 +357,7 @@ class TestScrape(ScrapeTestCase):
             'locale': 'en',
             'specs': [],
             'compat': [],
+            'footnotes': None,
             'issues': [],
             'errors': ["No <h2> found in page"],
         }
@@ -251,6 +376,7 @@ class TestScrape(ScrapeTestCase):
                 'section.id': None,
             }],
             'compat': [],
+            'footnotes': None,
             'issues': [],
             'errors': [
                 (251, 335, 'Unknown Specification "CSS3 Backgrounds"'),
@@ -277,7 +403,7 @@ class TestScrape(ScrapeTestCase):
                         'name': 'Chrome',
                         'id': '_Chrome',
                     }, {
-                        'name': 'Firefox (Gecko)',
+                        'name': 'Firefox',
                         'id': '_Firefox (Gecko)',
                     }, {
                         'name': 'Internet Explorer',
@@ -300,6 +426,7 @@ class TestScrape(ScrapeTestCase):
                         'obsolete': False,
                     }],
                 'supports': [],
+                'versions': [],
             }, {
                 'name': 'mobile',
                 'browsers': [
@@ -307,7 +434,7 @@ class TestScrape(ScrapeTestCase):
                         'name': 'Android',
                         'id': '_Android',
                     }, {
-                        'name': 'Firefox Mobile (Gecko)',
+                        'name': 'Firefox Mobile',
                         'id': '_Firefox Mobile (Gecko)',
                     }, {
                         'name': 'IE Mobile',
@@ -330,7 +457,9 @@ class TestScrape(ScrapeTestCase):
                         'obsolete': False,
                     }],
                 'supports': [],
+                'versions': [],
             }],
+            'footnotes': None,
             'issues': [],
             'errors': [
                 (902, 986, 'Unknown Specification "CSS3 Backgrounds"'),
@@ -368,7 +497,7 @@ class TestScrape(ScrapeTestCase):
                         'name': 'Chrome',
                         'id': self.browsers['chrome'].pk,
                     }, {
-                        'name': 'Firefox (Gecko)',
+                        'name': 'Firefox',
                         'id': self.browsers['firefox'].pk,
                     }, {
                         'name': 'Internet Explorer',
@@ -391,6 +520,7 @@ class TestScrape(ScrapeTestCase):
                         'obsolete': False,
                     }],
                 'supports': [],
+                'versions': [],
             }, {
                 'name': 'mobile',
                 'browsers': [
@@ -398,7 +528,7 @@ class TestScrape(ScrapeTestCase):
                         'name': 'Android',
                         'id': self.browsers['android'].pk,
                     }, {
-                        'name': 'Firefox Mobile (Gecko)',
+                        'name': 'Firefox Mobile',
                         'id': self.browsers['firefox-mobile'].pk,
                     }, {
                         'name': 'IE Mobile',
@@ -421,11 +551,128 @@ class TestScrape(ScrapeTestCase):
                         'obsolete': False,
                     }],
                 'supports': [],
+                'versions': [],
             }],
+            'footnotes': None,
             'issues': [],
             'errors': [],
         }
         self.assertScrape(self.simple_page, expected)
+
+    def test_complex_page_with_data(self):
+        self.add_models()
+        expected = {
+            'locale': 'en',
+            'specs': [{
+                'specification.mdn_key': 'CSS3 Backgrounds',
+                'specification.id': self.spec.id,
+                'section.subpath': '#the-background-size',
+                'section.name': 'background-size',
+                'section.note': '',
+                'section.id': self.section.id,
+            }],
+            'compat': [{
+                'name': 'desktop',
+                'browsers': [
+                    {
+                        'name': 'Chrome',
+                        'id': self.browsers['chrome'].pk,
+                    }, {
+                        'name': 'Firefox',
+                        'id': self.browsers['firefox'].pk,
+                    }, {
+                        'name': 'Internet Explorer',
+                        'id': self.browsers['ie'].pk,
+                    }, {
+                        'name': 'Opera',
+                        'id': self.browsers['opera'].pk,
+                    }, {
+                        'name': 'Safari',
+                        'id': self.browsers['safari'].pk,
+                    }],
+                'features': [
+                    {
+                        'name': 'Basic support',
+                        'id': '_Basic support',
+                        'slug': 'web-css-background-size_basic_support',
+                        'experimental': False,
+                        'standardized': True,
+                        'stable': True,
+                        'obsolete': False,
+                    }, {
+                        'id': (
+                            '_Support for<br>\n     <code>contain</code> and'
+                            ' <code>cover</code>'),
+                        'name': (
+                            'Support for<br>\n     <code>contain</code> and'
+                            ' <code>cover</code>'),
+                        'slug': (
+                            'web-css-background-size_support_for_br_code'
+                            '_contai'),
+                        'experimental': False,
+                        'standardized': True,
+                        'stable': True,
+                        'obsolete': False,
+                    }, {
+                        'name': 'Support for SVG backgrounds',
+                        'id': '_Support for SVG backgrounds',
+                        'slug': (
+                            'web-css-background-size_support_for_svg_'
+                            'background'),
+                        'experimental': False,
+                        'standardized': True,
+                        'stable': True,
+                        'obsolete': False,
+                    }],
+                'supports': [],
+                'versions': [],
+            }, {
+                'name': 'mobile',
+                'browsers': [
+                    {
+                        'name': 'Android',
+                        'id': self.browsers['android'].pk,
+                    }, {
+                        'name': 'Firefox Mobile',
+                        'id': self.browsers['firefox-mobile'].pk,
+                    }, {
+                        'name': 'IE Mobile',
+                        'id': self.browsers['ie-mobile'].pk,
+                    }, {
+                        'name': 'Opera Mobile',
+                        'id': self.browsers['opera-mobile'].pk,
+                    }, {
+                        'name': 'Safari Mobile',
+                        'id': self.browsers['safari-mobile'].pk,
+                    }],
+                'features': [
+                    {
+                        'name': 'Basic support',
+                        'id': '_Basic support',
+                        'slug': 'web-css-background-size_basic_support',
+                        'experimental': False,
+                        'standardized': True,
+                        'stable': True,
+                        'obsolete': False,
+                    }, {
+                        'name': 'Support for SVG backgrounds',
+                        'id': '_Support for SVG backgrounds',
+                        'slug': (
+                            'web-css-background-size_support_for_svg_'
+                            'background'),
+                        'experimental': False,
+                        'standardized': True,
+                        'stable': True,
+                        'obsolete': False,
+                    }],
+                'supports': [],
+                'versions': [],
+            }],
+            'footnotes': self.complex_compat_footnotes,
+            'issues': [],
+            'errors': [],
+        }
+        self.assertScrape(self.complex_page, expected)
 
     def test_feature_slug_is_unique(self):
         self.add_models()
@@ -448,6 +695,7 @@ class TestScrape(ScrapeTestCase):
             'locale': 'en',
             'specs': [],
             'compat': [],
+            'footnotes': None,
             'issues': [],
             'errors': [
                 (24, 52,
@@ -475,6 +723,7 @@ class TestScrape(ScrapeTestCase):
                 'section.id': None,
             }],
             'compat': [],
+            'footnotes': None,
             'issues': [
                 (0, 79,
                  'In Specifications section, expected <h2 id="Specifications">'

--- a/mdn/tests/test_scrape.py
+++ b/mdn/tests/test_scrape.py
@@ -40,6 +40,7 @@ class TestGrammar(TestCase):
 
 class ScrapeTestCase(TestCase):
     """Fixtures for scraping tests."""
+    longMessage = True
 
     # Based on:
     # https://developer.mozilla.org/en-US/docs/Web/CSS/background-size?raw
@@ -358,7 +359,7 @@ class TestPageVisitor(ScrapeTestCase):
         cell = self.visitor.visit(parsed)
         self.assertEqual(expected_cell, cell)
         expected_feature = {
-            'id': '_Some Feature',
+            'id': '_some feature',
             'name': 'Some Feature',
             'slug': 'web-css-background-size_some_feature',
         }
@@ -378,6 +379,34 @@ class TestPageVisitor(ScrapeTestCase):
         }]
         cell = self.visitor.visit(parsed)
         self.assertEqual(expected_cell, cell)
+
+    def test_compat_row_cell_feature_name_lookup(self):
+        texts = [
+            '<td>Some Feature</td>',
+            '<td>some feature</td>',
+            '<td rowspan="2">Some<br/>feature</td>',
+            '<td>SOME {{experimental_inline}} FEATURE</td>',
+            '<td><code>some feature</code></td>',
+        ]
+        expected_id = '_some feature'
+        expected_slug = 'web-css-background-size_some_feature'
+        for text in texts:
+            parsed = self.grammar['compat_row_cell'].parse(text)
+            cell = self.visitor.visit(parsed)
+            feature = self.visitor.cell_to_feature(cell)
+            self.assertEqual(expected_id, feature['id'], text)
+            self.assertEqual(expected_slug, feature['slug'], text)
+
+    def test_compat_row_cell_feature_match_canonical(self):
+        feature = self.create(
+            Feature, parent=self.visitor.feature,
+            name={'zxx': 'feature'}, slug='feature-slug')
+        text = '<td><code>feature</code></td>'
+        parsed = self.grammar['compat_row_cell'].parse(text)
+        cell = self.visitor.visit(parsed)
+        parsed_feature = self.visitor.cell_to_feature(cell)
+        self.assertEqual(parsed_feature['id'], feature.id)
+        self.assertEqual(parsed_feature['slug'], feature.slug)
 
     def test_compat_row_cell_feature_remove_whitespace(self):
         text = (
@@ -414,7 +443,7 @@ class TestPageVisitor(ScrapeTestCase):
         cell = self.visitor.visit(parsed)
         self.assertEqual(expected_cell, cell)
         expected_feature = {
-            'id': '_Support for <code>contain</code> and <code>cover</code>',
+            'id': '_support for contain and cover',
             'name': 'Support for <code>contain</code> and <code>cover</code>',
             'slug': 'web-css-background-size_support_for_contain_and_co',
         }
@@ -558,8 +587,6 @@ class TestPageVisitor(ScrapeTestCase):
 
 
 class TestScrape(ScrapeTestCase):
-    longMessage = True
-
     def setUp(self):
         self.add_compat_features()
 
@@ -647,7 +674,7 @@ class TestScrape(ScrapeTestCase):
                 'features': [
                     {
                         'name': 'Basic support',
-                        'id': '_Basic support',
+                        'id': '_basic support',
                         'slug': 'web-css-background-size_basic_support',
                     }],
                 'supports': [],
@@ -674,7 +701,7 @@ class TestScrape(ScrapeTestCase):
                 'features': [
                     {
                         'name': 'Basic support',
-                        'id': '_Basic support',
+                        'id': '_basic support',
                         'slug': 'web-css-background-size_basic_support',
                     }],
                 'supports': [],
@@ -733,7 +760,7 @@ class TestScrape(ScrapeTestCase):
                 'features': [
                     {
                         'name': 'Basic support',
-                        'id': '_Basic support',
+                        'id': '_basic support',
                         'slug': 'web-css-background-size_basic_support',
                     }],
                 'supports': [],
@@ -760,7 +787,7 @@ class TestScrape(ScrapeTestCase):
                 'features': [
                     {
                         'name': 'Basic support',
-                        'id': '_Basic support',
+                        'id': '_basic support',
                         'slug': 'web-css-background-size_basic_support',
                     }],
                 'supports': [],
@@ -806,12 +833,10 @@ class TestScrape(ScrapeTestCase):
                 'features': [
                     {
                         'name': 'Basic support',
-                        'id': '_Basic support',
+                        'id': '_basic support',
                         'slug': 'web-css-background-size_basic_support',
                     }, {
-                        'id': (
-                            '_Support for <code>contain</code> and'
-                            ' <code>cover</code>'),
+                        'id': '_support for contain and cover',
                         'name': (
                             'Support for <code>contain</code> and'
                             ' <code>cover</code>'),
@@ -820,7 +845,7 @@ class TestScrape(ScrapeTestCase):
                             '_and_co'),
                     }, {
                         'name': 'Support for SVG backgrounds',
-                        'id': '_Support for SVG backgrounds',
+                        'id': '_support for svg backgrounds',
                         'slug': (
                             'web-css-background-size_support_for_svg_'
                             'background'),
@@ -849,11 +874,11 @@ class TestScrape(ScrapeTestCase):
                 'features': [
                     {
                         'name': 'Basic support',
-                        'id': '_Basic support',
+                        'id': '_basic support',
                         'slug': 'web-css-background-size_basic_support',
                     }, {
                         'name': 'Support for SVG backgrounds',
-                        'id': '_Support for SVG backgrounds',
+                        'id': '_support for svg backgrounds',
                         'slug': (
                             'web-css-background-size_support_for_svg_'
                             'background'),

--- a/mdn/tests/test_scrape.py
+++ b/mdn/tests/test_scrape.py
@@ -488,6 +488,38 @@ class TestPageVisitor(ScrapeTestCase):
         errors = [(185, 357, 'Unknown Specification "HTML WHATWG"')]
         self.assertEqual(errors, self.visitor.errors)
 
+    def test_spec_no_thead(self):
+        # https://developer.mozilla.org/en-US/docs/Web/API/AudioContext
+        text = '''\
+<table class="standard-table">
+ <tbody>
+  <tr>
+   <th scope="col">Specification</th>
+   <th scope="col">Status</th>
+   <th scope="col">Comment</th>
+  </tr>
+  <tr>
+   <td>{{SpecName('Web Audio API', '#the-audiocontext-interface',\
+ 'AudioContext')}}</td>
+   <td>{{Spec2('Web Audio API')}}</td>
+   <td>&nbsp;</td>
+  </tr>
+ </tbody>
+</table>
+'''
+        parsed = page_grammar['spec_table'].parse(text)
+        self.visitor.visit(parsed)
+        expected = [{
+            'section.note': '',
+            'section.subpath': '#the-audiocontext-interface',
+            'section.name': 'AudioContext',
+            'specification.mdn_key': 'Web Audio API',
+            'section.id': None,
+            'specification.id': None}]
+        self.assertEqual(expected, self.visitor.specs)
+        errors = [(166, 251, 'Unknown Specification "Web Audio API"')]
+        self.assertEqual(errors, self.visitor.errors)
+
     def test_compat_row_cell_feature_with_rowspan(self):
         text = '<td rowspan="2">Some Feature</td>'
         parsed = page_grammar['compat_row_cell'].parse(text)

--- a/mdn/tests/test_scrape.py
+++ b/mdn/tests/test_scrape.py
@@ -1,0 +1,281 @@
+"""Test mdn.scrape."""
+from __future__ import unicode_literals
+from json import dumps
+
+from mdn.models import FeaturePage, TranslatedContent
+from mdn.scrape import scrape_page, scrape_feature_page, range_error_to_html
+from webplatformcompat.models import Feature, Maturity, Section, Specification
+from webplatformcompat.tests.base import TestCase
+
+
+class BaseTestCase(TestCase):
+    """Fixtures for scraping tests."""
+
+    # Based on:
+    # https://developer.mozilla.org/en-US/docs/Web/CSS/background-size?raw
+    # but with fixes (id of <h2>, remove &nbsp;).
+    simple_prefix = """\
+<div>
+ {{CSSRef}}</div>
+"""
+    simple_other_section = """\
+<h2 id="Summary">Summary</h2>
+<p>The <code>background-size</code> <a href="/en-US/docs/CSS" title="CSS">CSS\
+</a> property specifies the size of the background images. The size of the\
+ image can be fully constrained or only partially in order to preserve its\
+ intrinsic ratio.</p>
+<div class="note">
+ <strong>Note:</strong> If the value of this property is not set in a\
+ {{cssxref("background")}} shorthand property that is applied to the element\
+ after the <code>background-size</code> CSS property, the value of this\
+ property is then reset to its initial value by the shorthand property.</div>
+<p>{{cssbox("background-size")}}</p>
+"""
+    simple_spec_section = """\
+<h2 id="Specifications" name="Specifications">Specifications</h2>
+<table class="standard-table">
+ <thead>
+  <tr>
+   <th scope="col">Specification</th>
+   <th scope="col">Status</th>
+   <th scope="col">Comment</th>
+  </tr>
+ </thead>
+ <tbody>
+  <tr>
+   <td>{{SpecName('CSS3 Backgrounds', '#the-background-size',\
+ 'background-size')}}</td>
+   <td>{{Spec2('CSS3 Backgrounds')}}</td>
+   <td></td>
+  </tr>
+ </tbody>
+</table>
+"""
+
+    simple_see_also = """\
+<h2 id="See_also">See also</h2>
+<ul>
+ <li>{{CSS_Reference:Position}}</li>
+ <li><a href="/en-US/docs/Web/CSS/block_formatting_context">\
+Block formatting context</a></li>
+</ul>
+"""
+    simple_page = (
+        simple_prefix + simple_other_section + simple_spec_section +
+        simple_see_also)
+
+    def add_spec_models(self):
+        self.maturity = self.create(
+            Maturity, slug='CR', name='{"en": "Candidate Recommendation"}')
+        self.spec = self.create(
+            Specification, mdn_key='CSS3 Backgrounds',
+            slug='css3_backgrounds', maturity=self.maturity,
+            name='{"en": "CSS Backgrounds and Borders Module Level&nbsp;3"}',
+            uri='{"en": "http://dev.w3.org/csswg/css3-background/"}')
+        self.section = self.create(
+            Section, specification=self.spec, name='{"en": "background-size"}',
+            subpath='{"en": "#the-background-size"}')
+
+
+class TestScrape(BaseTestCase):
+    def test_empty(self):
+        out = scrape_page("")
+        expected = {
+            'locale': 'en',
+            'specs': [],
+            'issues': [],
+            'errors': ["No <h2> found in page"],
+        }
+        self.assertEqual(out, expected)
+
+    def test_spec_only(self):
+        """Test with a only a Specification section."""
+        out = scrape_page(self.simple_spec_section)
+        expected = {
+            'specs': [{
+                'specification.mdn_key': 'CSS3 Backgrounds',
+                'specification.id': None,
+                'section.subpath': '#the-background-size',
+                'section.name': 'background-size',
+                'section.note': '',
+                'section.id': None,
+            }],
+            'locale': 'en',
+            'issues': [],
+            'errors': [
+                (251, 335, 'Unknown Specification "CSS3 Backgrounds"'),
+            ]
+        }
+        self.assertEqual(expected, out)
+
+    def test_full_page(self):
+        """Test with a more complete but simple page."""
+        out = scrape_page(self.simple_page)
+        expected = {
+            'specs': [{
+                'specification.mdn_key': 'CSS3 Backgrounds',
+                'specification.id': None,
+                'section.subpath': '#the-background-size',
+                'section.name': 'background-size',
+                'section.note': '',
+                'section.id': None,
+            }],
+            'locale': 'en',
+            'issues': [],
+            'errors': [
+                (902, 986, 'Unknown Specification "CSS3 Backgrounds"'),
+            ]
+        }
+        self.assertEqual(expected, out)
+
+    def test_parse_error(self):
+        page = self.simple_page.replace("</h2>", "</h3")
+        out = scrape_page(page)
+        expected = {
+            'locale': 'en',
+            'specs': [],
+            'issues': [],
+            'errors': [
+                (40, 52,
+                 'Rule "attr" failed to match.  Rule definition:',
+                 'attr = _ ident _ equals _ qtext _')]
+        }
+        self.assertEqual(expected, out)
+
+
+class TestScrapeFeaturePage(BaseTestCase):
+    def setUp(self):
+        web = self.create(Feature, slug='web')
+        css = self.create(Feature, parent=web, slug='web-css')
+        self.background_size = self.create(
+            Feature, parent=css, slug='web-css-background')
+        url = ("https://developer.mozilla.org/en-US/docs/Web/CSS/"
+               "background-size")
+        self.page = FeaturePage.objects.create(
+            url=url, feature=self.background_size,
+            status=FeaturePage.STATUS_PARSING)
+        meta = self.page.meta()
+        meta.raw = dumps({
+            'locale': 'en-US',
+            'url': url,
+            'translations': [{
+                'locale': 'fr',
+                'url': url.replace('en-US', 'fr')
+            }]})
+        meta.status = meta.STATUS_FETCHED
+        meta.save()
+
+        for translation in self.page.translations():
+            translation.status = translation.STATUS_FETCHED
+            translation.raw = self.simple_page
+            translation.save()
+
+    def test_success(self):
+        scrape_feature_page(self.page)
+        fp = FeaturePage.objects.get(id=self.page.id)
+        self.assertEqual(fp.STATUS_PARSED, fp.status)
+        self.assertTrue(fp.has_issues)
+        section_ids = ["_CSS3 Backgrounds_#the-background-size"]
+        self.assertEqual(section_ids, fp.data['features']['links']['sections'])
+
+    def test_success_with_spec_data(self):
+        self.add_spec_models()
+        scrape_feature_page(self.page)
+        fp = FeaturePage.objects.get(id=self.page.id)
+        self.assertEqual(fp.STATUS_PARSED, fp.status)
+        self.assertFalse(fp.has_issues)
+        section_ids = [str(self.section.id)]
+        self.assertEqual(section_ids, fp.data['features']['links']['sections'])
+
+    def test_with_section_mismatch(self):
+        self.add_spec_models()
+        self.section.subpath['en'] = '#the-other-background-size'
+        self.section.save()
+        scrape_feature_page(self.page)
+        fp = FeaturePage.objects.get(id=self.page.id)
+        self.assertEqual(fp.STATUS_PARSED, fp.status)
+        self.assertFalse(fp.has_issues)
+        section_ids = ["%d_#the-background-size" % self.spec.id]
+        self.assertEqual(section_ids, fp.data['features']['links']['sections'])
+
+    def test_with_section_already_associated(self):
+        self.add_spec_models()
+        self.background_size.sections.add(self.section)
+        scrape_feature_page(self.page)
+        fp = FeaturePage.objects.get(id=self.page.id)
+        self.assertEqual(fp.STATUS_PARSED, fp.status)
+        self.assertFalse(fp.has_issues)
+        section_ids = [str(self.section.id)]
+        self.assertEqual(section_ids, fp.data['features']['links']['sections'])
+
+    def test_with_issues(self):
+        self.add_spec_models()
+        en_content = TranslatedContent.objects.get(
+            page=self.page, locale='en-US')
+
+        h2_fmt = '<h2 id="{0}" name="{0}">Specifications</h2>'
+        h2_good = h2_fmt.format('Specifications')
+        h2_bad = h2_fmt.format('Browser_Compatibility')
+        self.assertTrue(h2_good in en_content.raw)
+        en_content.raw = en_content.raw.replace(h2_good, h2_bad)
+        en_content.save()
+
+        scrape_feature_page(self.page)
+        fp = FeaturePage.objects.get(id=self.page.id)
+        self.assertEqual(fp.STATUS_PARSED, fp.status)
+        self.assertTrue(fp.has_issues)
+
+    def test_scrape_almost_empty_page(self):
+        self.add_spec_models()
+        en_content = TranslatedContent.objects.get(
+            page=self.page, locale='en-US')
+        en_content.raw = "<h1>nothing here</h1>"
+        en_content.save()
+
+        scrape_feature_page(self.page)
+        fp = FeaturePage.objects.get(id=self.page.id)
+        self.assertEqual(fp.STATUS_PARSED, fp.status)
+        self.assertTrue(fp.has_issues)
+        self.assertEqual(
+            ["<pre>No &lt;h2&gt; found in page</pre>"],
+            fp.data['meta']['scrape']['errors'])
+
+
+class TestRangeErrorToHtml(BaseTestCase):
+    def test_no_rule(self):
+        html = range_error_to_html(
+            self.simple_page, 902, 986,
+            'Unknown Specification "CSS3 Backgrounds"')
+        expected = """\
+<div><p>Unknown Specification &quot;CSS3 Backgrounds&quot;</p>\
+<p>Context:<pre>\
+16  &lt;tbody&gt;
+17   &lt;tr&gt;
+18    &lt;td&gt;{{SpecName(&#39;CSS3 Backgrounds&#39;, &#39;#the-background-\
+size&#39;, &#39;background-size&#39;)}}&lt;/td&gt;
+**    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\
+^^^^^^^^^^^^^^
+19    &lt;td&gt;{{Spec2(&#39;CSS3 Backgrounds&#39;)}}&lt;/td&gt;
+20    &lt;td&gt;&lt;/td&gt;
+</pre></p></div>"""
+        self.assertEqual(expected, html)
+
+    def test_rule(self):
+        html = range_error_to_html(
+            self.simple_page, 902, 986,
+            'Unknown Specification "CSS3 Backgrounds"',
+            'me = "awesome"')
+        expected = """\
+<div><p>Unknown Specification &quot;CSS3 Backgrounds&quot;</p>\
+<p><code>me = &quot;awesome&quot;</code></p>\
+<p>Context:<pre>\
+16  &lt;tbody&gt;
+17   &lt;tr&gt;
+18    &lt;td&gt;{{SpecName(&#39;CSS3 Backgrounds&#39;, &#39;#the-background-\
+size&#39;, &#39;background-size&#39;)}}&lt;/td&gt;
+**    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\
+^^^^^^^^^^^^^^
+19    &lt;td&gt;{{Spec2(&#39;CSS3 Backgrounds&#39;)}}&lt;/td&gt;
+20    &lt;td&gt;&lt;/td&gt;
+</pre></p></div>"""
+        self.assertEqual(expected, html)

--- a/mdn/tests/test_tasks.py
+++ b/mdn/tests/test_tasks.py
@@ -1,0 +1,336 @@
+"""Tests for mdn/tasks.py."""
+
+from __future__ import unicode_literals
+from json import dumps
+import mock
+
+
+from mdn.models import FeaturePage
+
+from mdn.tasks import (
+    start_crawl, fetch_meta, fetch_all_translations, fetch_translation,
+    parse_page)
+from webplatformcompat.models import Feature
+from webplatformcompat.tests.base import TestCase
+
+
+class TestStartCrawlTask(TestCase):
+    def setUp(self):
+        self.feature = self.create(Feature, slug='web-css-float')
+        self.fp = FeaturePage.objects.create(
+            feature=self.feature, status=FeaturePage.STATUS_STARTING,
+            url="https://developer.mozilla.org/en-US/docs/Web/CSS/float")
+        self.patcher_fetch_meta = mock.patch('mdn.tasks.fetch_meta.delay')
+        self.mocked_fetch_meta = self.patcher_fetch_meta.start()
+        self.mocked_fetch_meta.side_effect = Exception('Not Called')
+        self.patcher_fetch_all = mock.patch(
+            'mdn.tasks.fetch_all_translations.delay')
+        self.mocked_fetch_all = self.patcher_fetch_all.start()
+        self.mocked_fetch_all.side_effect = Exception('Not Called')
+
+    def tearDown(self):
+        self.patcher_fetch_meta.stop()
+        self.patcher_fetch_all.stop()
+
+    def test_no_meta(self):
+        self.mocked_fetch_meta.side_effect = None
+        start_crawl(self.fp.id)
+
+        fp = FeaturePage.objects.get(id=self.fp.id)
+        self.assertEqual(fp.STATUS_META, fp.status)
+        self.mocked_fetch_meta.assertCalledOnce(fp.id)
+
+    def test_meta_fetching(self):
+        meta = self.fp.meta()
+        meta.status = meta.STATUS_FETCHING
+        meta.save()
+        start_crawl(self.fp.id)
+
+        fp = FeaturePage.objects.get(id=self.fp.id)
+        self.assertEqual(fp.STATUS_META, fp.status)
+
+    def test_meta_fetched(self):
+        meta = self.fp.meta()
+        meta.status = meta.STATUS_FETCHED
+        meta.save()
+        self.mocked_fetch_all.side_effect = None
+        start_crawl(self.fp.id)
+
+        fp = FeaturePage.objects.get(id=self.fp.id)
+        self.assertEqual(fp.STATUS_PAGES, fp.status)
+        self.mocked_fetch_all.assertCalledOnce(fp.id)
+
+    def test_meta_error(self):
+        meta = self.fp.meta()
+        meta.status = meta.STATUS_ERROR
+        meta.raw = "META ERROR"
+        meta.save()
+        start_crawl(self.fp.id)
+
+        fp = FeaturePage.objects.get(id=self.fp.id)
+        self.assertEqual(fp.STATUS_ERROR, fp.status)
+        expected = [
+            '<pre>Failed to download %s: META ERROR</pre>' % meta.url()
+        ]
+        self.assertEqual(expected, fp.data['meta']['scrape']['errors'])
+
+
+class TestFetchMetaTask(TestCase):
+    def setUp(self):
+        self.feature = self.create(Feature, slug='web-css-float')
+        self.fp = FeaturePage.objects.create(
+            feature=self.feature, status=FeaturePage.STATUS_META,
+            url="https://developer.mozilla.org/en-US/docs/Web/CSS/float")
+        self.patcher_fetch_all = mock.patch(
+            'mdn.tasks.fetch_all_translations.delay')
+        self.mocked_fetch_all = self.patcher_fetch_all.start()
+        self.mocked_fetch_all.side_effect = Exception('Not Called')
+        self.patcher_get = mock.patch('mdn.tasks.requests.get')
+        self.mocked_get = self.patcher_get.start()
+        self.mocked_get.return_value = mock.Mock(
+            spec_set=['status_code', 'json', 'text', 'raise_for_status'])
+        self.response = self.mocked_get.return_value
+        self.response.status_code = 200
+        self.response.json.side_effect = Exception('Not Called')
+        self.response.text = ""
+        self.response.raise_for_status.side_effect = Exception('Not Called')
+
+    def tearDown(self):
+        self.patcher_fetch_all.stop()
+        self.patcher_get.stop()
+
+    def test_good_call(self):
+        data = {'foo': 'bar'}
+        self.response.json.side_effect = None
+        self.response.json.return_value = data
+        self.mocked_fetch_all.side_effect = None
+
+        fetch_meta(self.fp.id)
+        fp = FeaturePage.objects.get(id=self.fp.id)
+        self.assertEqual(fp.STATUS_PAGES, fp.status)
+        self.assertEqual([], fp.data['meta']['scrape']['errors'])
+        meta = fp.meta()
+        self.assertEqual(meta.STATUS_FETCHED, meta.status)
+        self.assertEqual(data, meta.data())
+        self.mocked_fetch_all.assertCalledOnce(self.fp.id)
+
+    def test_not_found(self):
+        self.response.status_code = 404
+        self.response.text = 'Not Found'
+        self.response.raise_for_status.side_effect = RuntimeError('Was Called')
+
+        self.assertRaises(RuntimeError, fetch_meta, self.fp.id)
+        fp = FeaturePage.objects.get(id=self.fp.id)
+        self.assertEqual(fp.STATUS_ERROR, fp.status)
+        expected_msg = "Status 404, Content:\nNot Found"
+        expected = [
+            '<pre>Failed to download %s$json: %s</pre>' % (
+                fp.url, expected_msg)]
+        self.assertEqual(expected, fp.data['meta']['scrape']['errors'])
+        meta = fp.meta()
+        self.assertEqual(meta.STATUS_ERROR, meta.status)
+        self.assertEqual(expected_msg, meta.raw)
+
+    def test_not_json(self):
+        self.response.json.side_effect = ValueError('Not JSON')
+        self.response.text = "I'm not JSON"
+
+        self.assertRaises(ValueError, fetch_meta, self.fp.id)
+        fp = FeaturePage.objects.get(id=self.fp.id)
+        self.assertEqual(fp.STATUS_ERROR, fp.status)
+        expected_msg = "Response is not JSON:\nI'm not JSON"
+        expected = [
+            '<pre>Failed to download %s$json: %s</pre>' % (
+                fp.url, expected_msg.replace("'", "&#39;"))]
+        self.assertEqual(expected, fp.data['meta']['scrape']['errors'])
+        meta = fp.meta()
+        self.assertEqual(meta.STATUS_ERROR, meta.status)
+        self.assertEqual(expected_msg, meta.raw)
+
+
+class TestFetchAllTranslationsTask(TestCase):
+    def setUp(self):
+        self.feature = self.create(Feature, slug='web-css-display')
+        self.fp = FeaturePage.objects.create(
+            feature=self.feature, status=FeaturePage.STATUS_PAGES,
+            url="https://developer.mozilla.org/en-US/docs/Web/CSS/float")
+        meta = self.fp.meta()
+        meta.status = meta.STATUS_FETCHED
+        meta.raw = dumps({
+            'locale': 'en-US',
+            'url': '/en-US/docs/Web/CSS/display',
+            'translations': [{
+                'locale': 'es',
+                'url': '/es/docs/Web/CSS/display',
+            }],
+        })
+        meta.save()
+
+        self.patcher_fetch_trans = mock.patch(
+            'mdn.tasks.fetch_translation.delay')
+        self.mocked_fetch_trans = self.patcher_fetch_trans.start()
+        self.mocked_fetch_trans.side_effect = Exception('Not Called')
+        self.patcher_parse_page = mock.patch('mdn.tasks.parse_page.delay')
+        self.mocked_parse_page = self.patcher_parse_page.start()
+        self.mocked_parse_page.side_effect = Exception('Not Called')
+
+    def tearDown(self):
+        self.patcher_fetch_trans.stop()
+        self.patcher_parse_page.stop()
+
+    def test_fetch_all_start(self):
+        self.mocked_fetch_trans.side_effect = None
+
+        fetch_all_translations(self.fp.id)
+        fp = FeaturePage.objects.get(id=self.fp.id)
+        self.assertEqual(fp.STATUS_PAGES, fp.status)
+        self.mocked_fetch_trans.assertCalledOnce(self.fp.id, 'en-US')
+        self.mocked_fetch_trans.assertCalledOnce(self.fp.id, 'es')
+
+    def test_fetch_all_in_progress(self):
+        for t in self.fp.translations():
+            t.status = t.STATUS_FETCHING
+            t.save()
+
+        fetch_all_translations(self.fp.id)
+        fp = FeaturePage.objects.get(id=self.fp.id)
+        self.assertEqual(fp.STATUS_PAGES, fp.status)
+
+    def test_fetch_all_complete(self):
+        for t in self.fp.translations():
+            t.status = t.STATUS_FETCHED
+            t.save()
+        self.mocked_parse_page.side_effect = None
+
+        fetch_all_translations(self.fp.id)
+        fp = FeaturePage.objects.get(id=self.fp.id)
+        self.assertEqual(fp.STATUS_PARSING, fp.status)
+        self.mocked_parse_page.assertCalledOnce(self.fp.id)
+
+    def test_fetch_one_error(self):
+        t = self.fp.translations()[-1]
+        t.status = t.STATUS_ERROR
+        t.raw = "Status 500, Content:\nServer Error"
+        t.save()
+
+        fetch_all_translations(self.fp.id)
+        fp = FeaturePage.objects.get(id=self.fp.id)
+        self.assertEqual(fp.STATUS_ERROR, fp.status)
+        expected = [
+            "<pre>Failed to download %s: %s</pre>" % (t.url(), t.raw)]
+        self.assertEqual(expected, fp.data['meta']['scrape']['errors'])
+
+
+class TestFetchTranslationTask(TestCase):
+    def setUp(self):
+        self.feature = self.create(Feature, slug='web-css-display')
+        self.fp = FeaturePage.objects.create(
+            feature=self.feature, status=FeaturePage.STATUS_PAGES,
+            url='https://developer.mozilla.org/en-US/docs/Web/CSS/display')
+        meta = self.fp.meta()
+        meta.status = meta.STATUS_FETCHED
+        meta.raw = dumps({
+            'locale': 'en-US',
+            'url': '/en-US/docs/Web/CSS/display',
+            'translations': [{
+                'locale': 'es',
+                'url': '/es/docs/Web/CSS/display',
+            }],
+        })
+        meta.save()
+        self.fp.translatedcontent_set.create(locale='en-US')
+        self.fp.translatedcontent_set.create(locale='es')
+
+        self.patcher_fetch_all = mock.patch(
+            'mdn.tasks.fetch_all_translations.delay')
+        self.mocked_fetch_all = self.patcher_fetch_all.start()
+        self.mocked_fetch_all.side_effect = Exception('Not Called')
+        self.patcher_get = mock.patch('mdn.tasks.requests.get')
+        self.mocked_get = self.patcher_get.start()
+        self.mocked_get.return_value = mock.Mock(
+            spec_set=['status_code', 'text', 'raise_for_status'])
+        self.response = self.mocked_get.return_value
+        self.response.status_code = 200
+        self.response.text = "Some page text"
+        self.response.raise_for_status.side_effect = Exception('Not Called')
+
+    def tearDown(self):
+        self.patcher_fetch_all.stop()
+        self.patcher_get.stop()
+
+    def test_good_call(self):
+        self.mocked_fetch_all.side_effect = None
+
+        fetch_translation(self.fp.id, 'en-US')
+        fp = FeaturePage.objects.get(id=self.fp.id)
+        self.assertEqual(fp.STATUS_PAGES, fp.status)
+        trans = fp.translatedcontent_set.get(locale='en-US')
+        self.assertEqual(trans.STATUS_FETCHED, trans.status)
+        self.mocked_fetch_all.assertCalledOnce(self.fp.id)
+
+    def test_parsing(self):
+        self.fp.status = self.fp.STATUS_PARSING
+        self.fp.save()
+        t = self.fp.translatedcontent_set.get(locale='en-US')
+        t.status = t.STATUS_FETCHED
+        t.save()
+
+        fetch_translation(self.fp.id, 'en-US')
+        fp = FeaturePage.objects.get(id=self.fp.id)
+        self.assertEqual(fp.STATUS_PARSING, fp.status)
+        trans = fp.translatedcontent_set.get(locale='en-US')
+        self.assertEqual(trans.STATUS_FETCHED, trans.status)
+
+    def test_parsed(self):
+        self.fp.status = self.fp.STATUS_PARSING
+        self.fp.save()
+        t = self.fp.translatedcontent_set.get(locale='en-US')
+        t.status = t.STATUS_FETCHED
+        t.save()
+
+        fetch_translation(self.fp.id, 'en-US')
+        fp = FeaturePage.objects.get(id=self.fp.id)
+        self.assertEqual(fp.STATUS_PARSING, fp.status)
+        trans = fp.translatedcontent_set.get(locale='en-US')
+        self.assertEqual(trans.STATUS_FETCHED, trans.status)
+
+    def test_not_found(self):
+        self.response.status_code = 404
+        self.response.text = 'Not Found'
+        self.response.raise_for_status.side_effect = RuntimeError('Was Called')
+
+        self.assertRaises(RuntimeError, fetch_translation, self.fp.id, 'es')
+        fp = FeaturePage.objects.get(id=self.fp.id)
+        self.assertEqual(fp.STATUS_ERROR, fp.status)
+        trans = fp.translatedcontent_set.get(locale='es')
+        self.assertEqual(trans.STATUS_ERROR, trans.status)
+        expected_msg = "Status 404, Content:\nNot Found"
+        self.assertEqual(expected_msg, trans.raw)
+        expected = [
+            '<pre>Failed to download %s: %s</pre>' % (
+                trans.url(), expected_msg)
+        ]
+        self.assertEqual(expected, fp.data['meta']['scrape']['errors'])
+
+
+class TestParsePageTask(TestCase):
+
+    @mock.patch('mdn.tasks.scrape_feature_page')
+    def test_call(self, mock_scrape):
+        fp = FeaturePage.objects.create(
+            feature_id=666, status=FeaturePage.STATUS_PARSING)
+        parse_page(fp.id)
+        mock_scrape.assertCalledOnce(fp.id)
+
+    @mock.patch('mdn.tasks.scrape_feature_page')
+    def test_exception(self, mock_scrape):
+        mock_scrape.side_effect = ValueError("Unexpected error")
+        feature = self.create(Feature, slug="the-slug")
+        fp = FeaturePage.objects.create(
+            feature=feature, status=FeaturePage.STATUS_PARSING)
+        self.assertRaises(ValueError, parse_page, fp.id)
+        mock_scrape.assertCalledOnce(fp.id)
+        fp = FeaturePage.objects.get(id=fp.id)
+        errors = fp.data['meta']['scrape']['errors']
+        self.assertEqual(1, len(errors))
+        self.assertEqual('<pre>Traceback ', errors[0][:15])

--- a/mdn/tests/test_tasks.py
+++ b/mdn/tests/test_tasks.py
@@ -100,7 +100,14 @@ class TestFetchMetaTask(TestCase):
         self.patcher_get.stop()
 
     def test_good_call(self):
-        data = {'foo': 'bar'}
+        data = {
+            'locale': 'en-US',
+            'url': '/en-US/docs/Web/CSS/display',
+            'translations': [{
+                'locale': 'es',
+                'url': '/es/docs/Web/CSS/display',
+            }],
+        }
         self.response.json.side_effect = None
         self.response.json.return_value = data
         self.mocked_fetch_all.side_effect = None

--- a/mdn/tests/test_views.py
+++ b/mdn/tests/test_views.py
@@ -82,7 +82,7 @@ class TestFeaturePageJSONView(TestCase):
     def test_get(self):
         feature_page = FeaturePage.objects.create(
             url="https://developer.mozilla.org/en-US/docs/Web/CSS/float",
-            feature_id=741, data='{"foo": "bar"}')
+            feature_id=741, data={"foo": "bar"})
         url = reverse('feature_page_json', kwargs={'pk': feature_page.id})
         response = self.client.get(url)
         self.assertEqual(200, response.status_code)

--- a/mdn/tests/test_views.py
+++ b/mdn/tests/test_views.py
@@ -1,0 +1,169 @@
+# -*- coding: utf-8 -*-
+"""Tests for MDN importer views."""
+
+from __future__ import unicode_literals
+import mock
+
+from django.core.urlresolvers import reverse
+
+from mdn.models import FeaturePage
+from webplatformcompat.models import Feature
+from webplatformcompat.tests.base import TestCase
+
+
+class TestFeaturePageListView(TestCase):
+    def setUp(self):
+        self.url = reverse('feature_page_list')
+
+    def test_empty_list(self):
+        response = self.client.get(self.url)
+        self.assertEqual(200, response.status_code)
+        pages = response.context_data['page_obj']
+        self.assertEqual(0, len(pages.object_list))
+
+    def test_populated_list(self):
+        feature_page = FeaturePage.objects.create(
+            url="https://developer.mozilla.org/en-US/docs/Web/CSS/display",
+            feature_id=1)
+        response = self.client.get(self.url)
+        self.assertEqual(200, response.status_code)
+        pages = response.context_data['page_obj']
+        self.assertEqual(1, len(pages.object_list))
+        obj = pages.object_list[0]
+        self.assertEqual(obj.id, feature_page.id)
+
+
+class TestFeaturePageCreateView(TestCase):
+    def setUp(self):
+        self.url = reverse('feature_page_create')
+        self.feature = self.create(Feature)
+
+    def test_get(self):
+        response = self.client.get(self.url)
+        self.assertEqual(200, response.status_code, response.content)
+
+    def test_get_prefill_url(self):
+        response = self.client.get(self.url, {'url': 'http://example.com'})
+        self.assertEqual(200, response.status_code, response.content)
+        self.assertContains(response, 'value="http://example.com"')
+
+    @mock.patch('mdn.views.start_crawl.delay')
+    def test_post_url(self, mock_task):
+        mdn_url = (
+            "https://developer.mozilla.org/en-US/docs/Web/CSS/animation-name")
+        data = {
+            "url": mdn_url,
+            "feature": self.feature.id
+        }
+        response = self.client.post(self.url, data)
+        self.assertEqual(302, response.status_code, response.content)
+        feature_page = FeaturePage.objects.get()
+        self.assertEqual(feature_page.url, mdn_url)
+        self.assertEqual(feature_page.feature_id, self.feature.id)
+        expected = 'http://testserver' + feature_page.get_absolute_url()
+        self.assertEqual(expected, response["LOCATION"])
+        mock_task.assertCalledOnce(feature_page.id)
+
+
+class TestFeaturePageDetailView(TestCase):
+    def test_get(self):
+        feature = self.create(Feature, slug='web-css-float')
+        feature_page = FeaturePage.objects.create(
+            url="https://developer.mozilla.org/en-US/docs/Web/CSS/float",
+            feature=feature)
+        url = reverse('feature_page_detail', kwargs={'pk': feature_page.id})
+        response = self.client.get(url)
+        self.assertEqual(200, response.status_code)
+        obj = response.context_data['object']
+        self.assertEqual(obj.id, feature_page.id)
+
+
+class TestFeaturePageJSONView(TestCase):
+    def test_get(self):
+        feature_page = FeaturePage.objects.create(
+            url="https://developer.mozilla.org/en-US/docs/Web/CSS/float",
+            feature_id=741, data='{"foo": "bar"}')
+        url = reverse('feature_page_json', kwargs={'pk': feature_page.id})
+        response = self.client.get(url)
+        self.assertEqual(200, response.status_code)
+        self.assertEqual('application/json', response['Content-Type'])
+        self.assertEqual(b'{"foo": "bar"}', response.content)
+
+
+class TestFeaturePageSearch(TestCase):
+    def setUp(self):
+        self.url = reverse('feature_page_search')
+        self.mdn_url = "https://developer.mozilla.org/en-US/docs/Web/CSS/float"
+
+    def test_get(self):
+        response = self.client.get(self.url)
+        self.assertEqual(200, response.status_code)
+        self.assertEqual("Search by URL", response.context_data['action'])
+
+    def test_post_found(self):
+        fp = FeaturePage.objects.create(
+            url=self.mdn_url, feature_id=741, data='{"foo": "bar"}')
+        response = self.client.post(self.url, {'url': self.mdn_url})
+        next_url = reverse('feature_page_detail', kwargs={'pk': fp.id})
+        self.assertRedirects(response, next_url)
+
+    def test_not_found_with_perms(self):
+        self.login_superuser()
+        response = self.client.post(self.url, {'url': self.mdn_url})
+        next_url = reverse('feature_page_create') + '?url=' + self.mdn_url
+        self.assertRedirects(response, next_url)
+
+    def test_not_found_without_perms(self):
+        response = self.client.post(self.url, {'url': self.mdn_url})
+        next_url = reverse('feature_page_list')
+        self.assertRedirects(response, next_url)
+
+
+class TestFeaturePageReParseView(TestCase):
+
+    def setUp(self):
+        self.feature = self.create(Feature, slug='web-css-float')
+        self.fp = FeaturePage.objects.create(
+            url="https://developer.mozilla.org/en-US/docs/Web/CSS/float",
+            feature=self.feature, data='{"foo": "bar"}',
+            status=FeaturePage.STATUS_PARSED)
+        self.url = reverse('feature_page_reparse', kwargs={'pk': self.fp.pk})
+
+    def test_get(self):
+        response = self.client.get(self.url)
+        self.assertEqual(200, response.status_code)
+        self.assertEqual("Re-parse MDN Page", response.context_data['action'])
+
+    @mock.patch('mdn.views.parse_page.delay')
+    def test_post(self, mocked_parse):
+        response = self.client.post(self.url)
+        dest_url = reverse('feature_page_detail', kwargs={'pk': self.fp.pk})
+        self.assertRedirects(response, dest_url)
+        mocked_parse.assertCalledOnce(self.fp.pk)
+        fp = FeaturePage.objects.get(id=self.fp.id)
+        self.assertEqual(fp.STATUS_PARSING, fp.status)
+
+
+class TestFeaturePageResetView(TestCase):
+
+    def setUp(self):
+        self.feature = self.create(Feature, slug='web-css-float')
+        self.fp = FeaturePage.objects.create(
+            url="https://developer.mozilla.org/en-US/docs/Web/CSS/float",
+            feature_id=self.feature.id, data='{"foo": "bar"}',
+            status=FeaturePage.STATUS_PARSED)
+        self.url = reverse('feature_page_reset', kwargs={'pk': self.fp.pk})
+
+    def test_get(self):
+        response = self.client.get(self.url)
+        self.assertEqual(200, response.status_code)
+        self.assertEqual("Reset MDN Page", response.context_data['action'])
+
+    @mock.patch('mdn.views.start_crawl.delay')
+    def test_post(self, mocked_crawl):
+        response = self.client.post(self.url)
+        dest_url = reverse('feature_page_detail', kwargs={'pk': self.fp.pk})
+        self.assertRedirects(response, dest_url)
+        mocked_crawl.assertCalledOnce(self.fp.pk)
+        fp = FeaturePage.objects.get(id=self.fp.id)
+        self.assertEqual(fp.STATUS_STARTING, fp.status)

--- a/mdn/tests/test_views.py
+++ b/mdn/tests/test_views.py
@@ -103,18 +103,18 @@ class TestFeaturePageSearch(TestCase):
     def test_post_found(self):
         fp = FeaturePage.objects.create(
             url=self.mdn_url, feature_id=741, data='{"foo": "bar"}')
-        response = self.client.post(self.url, {'url': self.mdn_url})
+        response = self.client.get(self.url, {'url': self.mdn_url})
         next_url = reverse('feature_page_detail', kwargs={'pk': fp.id})
         self.assertRedirects(response, next_url)
 
     def test_not_found_with_perms(self):
         self.login_superuser()
-        response = self.client.post(self.url, {'url': self.mdn_url})
+        response = self.client.get(self.url, {'url': self.mdn_url})
         next_url = reverse('feature_page_create') + '?url=' + self.mdn_url
         self.assertRedirects(response, next_url)
 
     def test_not_found_without_perms(self):
-        response = self.client.post(self.url, {'url': self.mdn_url})
+        response = self.client.get(self.url, {'url': self.mdn_url})
         next_url = reverse('feature_page_list')
         self.assertRedirects(response, next_url)
 

--- a/mdn/urls.py
+++ b/mdn/urls.py
@@ -1,0 +1,15 @@
+from django.conf.urls import patterns, url
+
+
+mdn_urlpatterns = patterns(
+    'mdn.views',
+    url(r'^$', 'feature_page_list', name='feature_page_list'),
+    url(r'^create$', 'feature_page_create', name='feature_page_create'),
+    url(r'^search$', 'feature_page_search', name='feature_page_search'),
+    url(r'^(?P<pk>\d+)$', 'feature_page_detail', name='feature_page_detail'),
+    url(r'^(?P<pk>\d+)\.json$', 'feature_page_json', name='feature_page_json'),
+    url(r'^(?P<pk>\d+)/reset$', 'feature_page_reset',
+        name='feature_page_reset'),
+    url(r'^(?P<pk>\d+)/reparse$', 'feature_page_reparse',
+        name='feature_page_reparse')
+)

--- a/mdn/views.py
+++ b/mdn/views.py
@@ -26,7 +26,7 @@ class FeaturePageListView(ListView):
     paginate_by = 50
 
     def get_queryset(self):
-        return FeaturePage.objects.order_by('modified')
+        return FeaturePage.objects.order_by('feature_id')
 
     def get_context_data(self, **kwargs):
         ctx = super(FeaturePageListView, self).get_context_data(**kwargs)

--- a/mdn/views.py
+++ b/mdn/views.py
@@ -1,7 +1,4 @@
 """Views for MDN migration app."""
-from collections import OrderedDict
-from json import loads
-
 from django import forms
 from django.contrib.auth.decorators import user_passes_test
 from django.contrib import messages
@@ -74,7 +71,7 @@ class FeaturePageJSONView(BaseDetailView):
 
     def render_to_response(self, context):
         obj = context['object']
-        return JsonResponse(loads(obj.data, object_pairs_hook=OrderedDict))
+        return JsonResponse(obj.data)
 
 
 class SearchForm(forms.Form):

--- a/mdn/views.py
+++ b/mdn/views.py
@@ -20,6 +20,10 @@ def can_create(user):
     return user.is_authenticated and user.is_staff
 
 
+def can_refresh(user):
+    return True
+
+
 class FeaturePageListView(ListView):
     model = FeaturePage
     template_name = "mdn/feature_page_list.jinja2"
@@ -191,7 +195,7 @@ feature_page_detail = FeaturePageDetailView.as_view()
 feature_page_json = FeaturePageJSONView.as_view()
 feature_page_search = FeaturePageSearch.as_view()
 feature_page_list = FeaturePageListView.as_view()
-feature_page_reset = user_passes_test(can_create)(
+feature_page_reset = user_passes_test(can_refresh)(
     FeaturePageReset.as_view())
-feature_page_reparse = user_passes_test(can_create)(
+feature_page_reparse = user_passes_test(can_refresh)(
     FeaturePageReParse.as_view())

--- a/requirements.txt
+++ b/requirements.txt
@@ -81,3 +81,6 @@ requests==2.4.3
 
 # CORS headers in middleware
 git+git://github.com/ottoyiu/django-cors-headers@5d5eeccf7ce#egg=django-cors-headers
+
+# Parsing Expression Grammar, for MDN scraping
+parsimonious==0.6.2

--- a/tools/client.py
+++ b/tools/client.py
@@ -106,7 +106,7 @@ class Client(object):
             'csrfmiddlewaretoken': csrf,
             'next': next_path
         }
-
+        self.session.headers['referer'] = url
         response = self.session.post(
             self.base_url + '/api-auth/login/', params=params, data=data)
         if response.url == self.base_url + next_path:

--- a/tools/gather_import_errors.py
+++ b/tools/gather_import_errors.py
@@ -1,0 +1,194 @@
+#!/usr/bin/env python
+
+from __future__ import print_function
+
+from collections import Counter
+from HTMLParser import HTMLParser
+import csv
+import logging
+import os.path
+import re
+import sys
+import time
+
+from client import Client
+
+logger = logging.getLogger('tools.gather_import_errors')
+my_dir = os.path.dirname(os.path.realpath(__file__))
+data_dir = os.path.realpath(os.path.join(my_dir, '..', 'data'))
+BY_URL_CSV_FILENAME = os.path.join(data_dir, 'import_errors_by_url.csv')
+BY_ERRORS_CSV_FILENAME = os.path.join(data_dir, 'import_error_counts.csv')
+
+
+class GatherLinks(HTMLParser):
+    re_url = re.compile(r'^/importer/(?P<num>\d+)$')
+
+    def __init__(self, *args, **kwargs):
+        self.import_ids = set()
+        HTMLParser.__init__(self, *args, **kwargs)
+
+    def handle_starttag(self, tag, attrs):
+        if tag == 'a':
+            for attr, value in attrs:
+                if attr == 'href':
+                    m = self.re_url.match(value)
+                    if m:
+                        self.import_ids.add(int(m.group("num")))
+
+    def get_urls(self):
+        return ["/importer/%d.json" % i for i in sorted(self.import_ids)]
+
+
+def gather_import_errors(client, by_url_csv, by_error_csv):
+    error_rows = download_errors(client)
+    error_counts = Counter()
+
+    # Write by-url CSV and count errors
+    by_url_writer = csv.writer(by_url_csv)
+    by_url_writer.writerow(
+        ["MDN Slug", "Import URL", "Source Start", "Source End", "Error",
+         "Rule"])
+    for row in error_rows:
+        err = row[4]
+        error_counts[err] += 1
+        by_url_writer.writerow(row)
+
+    # Write by_error CSV
+    by_error_writer = csv.writer(by_error_csv)
+    by_error_writer.writerow(["Count", "Error"])
+    for err, count in error_counts.most_common():
+        by_error_writer.writerow((count, err))
+
+    return {
+        'total': len(error_rows),
+        'unique': len(error_counts),
+    }
+
+
+def download_errors(client):
+    # Gather import links
+    start = time.time()
+    logger.info("Gathering import URLs from %s...", client.base_url)
+    page = 1
+    parser = GatherLinks()
+    status = 200
+    while status == 200:
+        index_url = client.base_url + '/importer/'
+        index_resp = client.session.get(index_url, params={'page': page})
+        status = index_resp.status_code
+        if status == 200:
+            parser.feed(index_resp.text)
+            page += 1
+    import_urls = parser.get_urls()
+    total_urls = len(import_urls)
+    end = time.time()
+    logger.info("Found %d import URLs in %0.1fs", total_urls, end - start)
+
+    # Gather errors
+    error_rows = []
+    start = time.time()
+    for url_count, raw_url in enumerate(import_urls):
+        url = client.base_url + raw_url
+        human_import_url = url.replace('.json', '')
+        resp = client.session.get(url)
+        resp.raise_for_status()
+        resp_json = resp.json()
+        mdn_uri = resp_json['features']['mdn_uri']['en']
+        mdn_prefix = 'https://developer.mozilla.org/en-US/docs/'
+        assert mdn_uri.startswith(mdn_prefix)
+        mdn_slug = mdn_uri.replace(mdn_prefix, '', 1)
+        errors = resp_json['meta']['scrape']['raw']['errors']
+        for err in errors:
+            if isinstance(err, list):
+                start_pos, end_pos, msg = err[:3]
+                if len(err) == 4:
+                    rule = err[3]
+                else:
+                    rule = ""
+            else:
+                msg = err
+                start_pos = end_pos = rule = ''
+            error_rows.append(
+                (mdn_slug, human_import_url, start_pos, end_pos,
+                 msg.encode('utf-8'), rule))
+        end = time.time()
+        if (end - start) > 15:
+            percent = 100.0 * (total_urls - url_count + 1.0) / total_urls
+            logger.info(
+                "Found %d errors in %d imports (%d%%)",
+                len(error_rows), url_count + 1, percent)
+            start = time.time()
+
+    return error_rows
+
+
+if __name__ == '__main__':
+    import argparse
+    description = 'Gather import errors into CSVs.'
+    parser = argparse.ArgumentParser(description=description)
+    parser.add_argument(
+        '-a', '--api',
+        help='Base URL of the API (default: http://localhost:8000)',
+        default="http://localhost:8000")
+    parser.add_argument(
+        '-v', '--verbose', action="store_true",
+        help='Print extra debug information')
+    parser.add_argument(
+        '-q', '--quiet', action="store_true",
+        help='Only print warnings')
+    args = parser.parse_args()
+
+    # Setup logging
+    verbose = args.verbose
+    quiet = args.quiet
+    console = logging.StreamHandler(sys.stderr)
+    formatter = logging.Formatter('%(levelname)s - %(message)s')
+    logger_name = 'tools'
+    fmat = '%(levelname)s - %(message)s'
+    if quiet:
+        level = logging.WARNING
+    elif verbose:
+        level = logging.DEBUG
+        logger_name = ''
+        fmat = '%(name)s - %(levelname)s - %(message)s'
+    else:
+        level = logging.INFO
+    formatter = logging.Formatter(fmat)
+    console.setLevel(level)
+    console.setFormatter(formatter)
+    logger = logging.getLogger(logger_name)
+    logger.setLevel(level)
+    logger.addHandler(console)
+
+    # Parse arguments
+    api = args.api
+    if api.endswith('/'):
+        api = api[:-1]
+    logger.info("Loading importer errors from %s" % api)
+
+    # Initialize client
+    client = Client(api)
+
+    # Gather errors and write to CSVs
+    counts = {}
+    by_url_csv = None
+    by_error_csv = None
+    try:
+        by_url_csv = open(BY_URL_CSV_FILENAME, "wb")
+        by_error_csv = open(BY_ERRORS_CSV_FILENAME, "wb")
+        counts = gather_import_errors(client, by_url_csv, by_error_csv)
+    finally:
+        if by_error_csv:
+            by_error_csv.close()
+        if by_url_csv:
+            by_url_csv.close()
+
+    if counts:
+        c_unique = counts.get('unique', 0)
+        c_total = counts.get('total', 0)
+        logger.info(
+            "Errors collected: %d unique (%d total)", c_unique, c_total)
+        logger.info("Error details in %s", BY_URL_CSV_FILENAME)
+        logger.info("Error counts in %s", BY_ERRORS_CSV_FILENAME)
+    else:
+        logger.info("No errors found.")

--- a/tools/import_mdn.py
+++ b/tools/import_mdn.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python
+
+from __future__ import print_function
+
+import getpass
+import logging
+import os.path
+import sys
+import time
+
+from client import Client
+from resources import Collection
+
+try:
+    input = raw_input  # Get the Py2 raw_input
+except NameError:
+    pass  # We're in Py3
+
+logger = logging.getLogger('tools.import_mdn')
+my_dir = os.path.dirname(os.path.realpath(__file__))
+data_dir = os.path.realpath(os.path.join(my_dir, '..', 'data'))
+
+
+def import_mdn_data(client, rate=5):
+    collection = Collection(client)
+    collection.load_all('features')
+
+    # Collect feature URIs
+    uris = []
+    for feature in collection.get_resources('features'):
+        if feature.mdn_uri and feature.mdn_uri.get('en'):
+            uris.append((feature.mdn_uri['en'], feature.id.id))
+    total = len(uris)
+    logger.info('Features loaded, %d MDN pages found.', total)
+
+    # Import from MDN, with rate limiting
+    start_time = time.time()
+    mdn_requests = 0
+    counts = {'new': 0, 'reset': 0, 'reparsed': 0, 'unchanged': 0}
+    importer_search = client.base_url + '/importer/search'
+    log_at = 15
+    logged_at = time.time()
+    for uri, f_id in uris:
+        response = client.session.get(importer_search, params={'url': uri})
+        if 'importer/create?' in response.url:
+            logger.info('Fetching %s...', uri)
+            counts['new'] += 1
+            create_url = response.url
+            csrf = client.session.cookies['csrftoken']
+            params = {
+                'url': uri,
+                'feature': f_id,
+                'csrfmiddlewaretoken': csrf,
+            }
+            response = client.session.post(create_url, params)
+            mdn_requests += 1
+        else:
+            response.raise_for_status()
+            obj_url = response.url
+            assert '/importer/' in obj_url
+            reparse_url = obj_url + '/reparse'
+            csrf = client.session.cookies['csrftoken']
+            params = {'csrfmiddlewaretoken': csrf}
+            response = client.session.post(reparse_url, params)
+            counts['reparsed'] += 1
+
+        # Pause for rate limiting?
+        current_time = time.time()
+        if rate:
+            elapsed = current_time - start_time
+            target = start_time + float(mdn_requests) / rate
+            current_rate = float(mdn_requests) / elapsed
+            if time.time < target:
+                rest = int(target - current_time) + 1
+                logger.warning(
+                    "%d pages fetched, %0.2f per second, target rate %d per"
+                    " second.  Resting %d seconds.",
+                    mdn_requests, current_rate, rate, rest)
+                time.sleep(rest)
+                logged_at = time.time()
+                current_time = time.time()
+
+        # Log progress?
+        if (logged_at + log_at) < current_time:
+            processed = sum(counts.values())
+            percent = int(100 * (float(processed) / total))
+            logger.info(
+                "  Processed %d of %d MDN pages (%d%%)...",
+                processed, total, percent)
+            logged_at = current_time
+
+    return counts
+
+
+if __name__ == '__main__':
+    import argparse
+    description = 'Import features from MDN, or reparse imported features.'
+    parser = argparse.ArgumentParser(description=description)
+    parser.add_argument(
+        '-a', '--api',
+        help='Base URL of the API (default: http://localhost:8000)',
+        default="http://localhost:8000")
+    parser.add_argument(
+        '-u', '--user',
+        help='Username on API (default: prompt for username)')
+    parser.add_argument(
+        '-v', '--verbose', action="store_true",
+        help='Print extra debug information')
+    parser.add_argument(
+        '-q', '--quiet', action="store_true",
+        help='Only print warnings')
+    args = parser.parse_args()
+
+    # Setup logging
+    verbose = args.verbose
+    quiet = args.quiet
+    console = logging.StreamHandler(sys.stderr)
+    formatter = logging.Formatter('%(levelname)s - %(message)s')
+    logger_name = 'tools'
+    fmat = '%(levelname)s - %(message)s'
+    if quiet:
+        level = logging.WARNING
+    elif verbose:
+        level = logging.DEBUG
+        logger_name = ''
+        fmat = '%(name)s - %(levelname)s - %(message)s'
+    else:
+        level = logging.INFO
+    formatter = logging.Formatter(fmat)
+    console.setLevel(level)
+    console.setFormatter(formatter)
+    logger = logging.getLogger(logger_name)
+    logger.setLevel(level)
+    logger.addHandler(console)
+
+    # Parse arguments
+    api = args.api
+    if api.endswith('/'):
+        api = api[:-1]
+    logger.info("Loading data into %s" % api)
+
+    # Get credentials
+    user = args.user or input("API username: ")
+    password = getpass.getpass("API password: ")
+
+    # Initialize client
+    client = Client(api)
+    client.login(user, password)
+
+    # Load data
+    counts = import_mdn_data(client)
+
+    if counts:
+        logger.info("Import complete. Counts:")
+        c_new = counts.get('new', 0)
+        c_reset = counts.get('reset', 0)
+        c_reparsed = counts.get('reparsed', 0)
+        c_unchanged = counts.get('unchanged', 0)
+        c_text = []
+        if c_new:
+            c_text.append("%d new" % c_new)
+        if c_reset:
+            c_text.append("%d reset" % c_reset)
+        if c_reparsed:
+            c_text.append("%d reparsed" % c_reparsed)
+        if c_unchanged:
+            c_text.append("%d unchanged" % c_unchanged)
+        if c_text:
+            logger.info(', '.join(c_text))
+    else:
+        logger.info("No data uploaded.")

--- a/tools/load_spec_data.py
+++ b/tools/load_spec_data.py
@@ -225,6 +225,7 @@ def parse_spec2(specname, local_collection):
 
 
 def slugify(word, attempt=0):
+    # TODO: replace with mdn.scrape.slugify
     raw = word.lower().encode('utf-8')
     out = []
     acceptable = string.ascii_lowercase + string.digits + '_-'

--- a/tools/load_spec_data.py
+++ b/tools/load_spec_data.py
@@ -21,9 +21,11 @@ except NameError:
     pass  # We're in Py3
 
 logger = logging.getLogger('tools.load_spec_data')
-SPEC2_FILENAME = 'Spec2.txt'
+my_dir = os.path.dirname(os.path.realpath(__file__))
+data_dir = os.path.realpath(os.path.join(my_dir, '..', 'data'))
+SPEC2_FILENAME = os.path.join(data_dir, 'Spec2.txt')
 SPEC2_URL = 'https://developer.mozilla.org/en-US/docs/Template:Spec2?raw'
-SPECNAME_FILENAME = 'SpecName.txt'
+SPECNAME_FILENAME = os.path.join(data_dir, 'SpecName.txt')
 SPECNAME_URL = 'https://developer.mozilla.org/en-US/docs/Template:SpecName?raw'
 
 
@@ -32,7 +34,7 @@ def get_template(filename, url):
         logger.info("Downloading " + filename)
         r = requests.get(url)
         with codecs.open(filename, 'wb', 'utf8') as f:
-            f.write(r.content)
+            f.write(r.text)
     else:
         logger.info("Using existing " + filename)
 
@@ -50,6 +52,14 @@ def load_spec_data(client, specname, spec2, confirm=None):
     load_api_spec_data(api_collection)
     logger.info('Reading spec data from MDN templates')
     parse_spec_data(specname, spec2, api_collection, local_collection)
+
+    # Load API sections into local collection
+    local_collection.override_ids_to_match(api_collection)
+    local_specs = local_collection.get_resources('specifications')
+    for local_spec in local_specs:
+        api_spec = api_collection.get('specifications', local_spec.id.id)
+        if api_spec:
+            local_spec.sections = api_spec.sections.ids
 
     changeset = CollectionChangeset(api_collection, local_collection)
     delta = changeset.changes

--- a/tools/load_webcompat_data.py
+++ b/tools/load_webcompat_data.py
@@ -126,6 +126,7 @@ def parse_compat_data(compat_data, local_collection):
 
 
 def slugify(word, attempt=0):
+    # TODO: replace with mdn.scrape.slugify
     raw = word.lower().encode('utf-8')
     out = []
     acceptable = string.ascii_lowercase + string.digits + '_-'

--- a/tools/load_webcompat_data.py
+++ b/tools/load_webcompat_data.py
@@ -26,7 +26,9 @@ except NameError:
 
 
 logger = logging.getLogger('tools.load_webcompat_data')
-COMPAT_DATA_FILENAME = "data-human.json"
+my_dir = os.path.dirname(os.path.realpath(__file__))
+data_dir = os.path.realpath(os.path.join(my_dir, '..', 'data'))
+COMPAT_DATA_FILENAME = os.path.join(data_dir, "data-human.json")
 COMPAT_DATA_URL = (
     "https://raw.githubusercontent.com/webplatform/compatibility-data"
     "/master/data-human.json")
@@ -55,7 +57,7 @@ def get_compat_data(filename, url):
         logger.info("Downloading " + filename)
         r = requests.get(url)
         with codecs.open(filename, 'wb', 'utf8') as f:
-            f.write(r.content)
+            f.write(r.text)
     else:
         logger.info("Using existing " + filename)
 

--- a/tools/resources.py
+++ b/tools/resources.py
@@ -334,7 +334,7 @@ class Section(Resource):
     def number_en(self):
         if self.number is None:
             return None
-        return self.number['en']
+        return self.number.get('en', None)
 
 
 class Maturity(Resource):

--- a/tools/tests/test_resources.py
+++ b/tools/tests/test_resources.py
@@ -400,6 +400,33 @@ class TestSection(TestCase):
         collection.add(section)
         self.assertEqual(('sections', '', 'SPEC'), section.get_data_id())
 
+    def test_with_empty_number(self):
+        section = Section(
+            name={'en': 'section foo'}, subpath={'en': '/foo'},
+            specification='_spec', number={})
+        expected = {
+            "sections": {
+                "name": {'en': 'section foo'},
+                "number": {},
+                "subpath": {'en': '/foo'},
+                "links": {
+                    "specification": "_spec",
+                }}}
+        self.assertEqual(expected, section.to_json_api())
+
+    def test_get_data_id_with_empty_number(self):
+        maturity = Maturity(id="2")
+        spec = Specification(id="22", maturity="2", mdn_key="SPEC")
+        feature = Feature(id="222")
+        section = Section(
+            id="_sec", specification="22", features=["222"], number={})
+        collection = Collection()
+        collection.add(maturity)
+        collection.add(spec)
+        collection.add(feature)
+        collection.add(section)
+        self.assertEqual(('sections', '', 'SPEC'), section.get_data_id())
+
 
 class TestMaturity(TestCase):
     def test_to_json(self):

--- a/tools/tests/test_resources.py
+++ b/tools/tests/test_resources.py
@@ -349,17 +349,56 @@ class TestSpecification(TestCase):
 class TestSection(TestCase):
     def test_to_json(self):
         section = Section(
-            number={'en': '1.2.3'}, name={'en': 'Section Foo'},
+            number={'en': '1.2.3'}, name={'en': 'section foo'},
             subpath={'en': '/foo'}, specification='_spec')
         expected = {
             "sections": {
                 "number": {'en': '1.2.3'},
-                "name": {'en': 'Section Foo'},
+                "name": {'en': 'section foo'},
                 "subpath": {'en': '/foo'},
                 "links": {
                     "specification": "_spec",
                 }}}
         self.assertEqual(expected, section.to_json_api())
+
+    def test_get_data_id_with_number(self):
+        maturity = Maturity(id="2")
+        spec = Specification(id="22", maturity="2", mdn_key="SPEC")
+        feature = Feature(id="222")
+        section = Section(
+            id="_sec", specification="22", features=["222"],
+            number={"en": "1.2.3"})
+        collection = Collection()
+        collection.add(maturity)
+        collection.add(spec)
+        collection.add(feature)
+        collection.add(section)
+        self.assertEqual(('sections', '1.2.3', 'SPEC'), section.get_data_id())
+
+    def test_without_number(self):
+        section = Section(
+            name={'en': 'section foo'}, subpath={'en': '/foo'},
+            specification='_spec')
+        expected = {
+            "sections": {
+                "name": {'en': 'section foo'},
+                "subpath": {'en': '/foo'},
+                "links": {
+                    "specification": "_spec",
+                }}}
+        self.assertEqual(expected, section.to_json_api())
+
+    def test_get_data_id_without_number(self):
+        maturity = Maturity(id="2")
+        spec = Specification(id="22", maturity="2", mdn_key="SPEC")
+        feature = Feature(id="222")
+        section = Section(id="_sec", specification="22", features=["222"])
+        collection = Collection()
+        collection.add(maturity)
+        collection.add(spec)
+        collection.add(feature)
+        collection.add(section)
+        self.assertEqual(('sections', '', 'SPEC'), section.get_data_id())
 
 
 class TestMaturity(TestCase):

--- a/tools/upload_data.py
+++ b/tools/upload_data.py
@@ -97,7 +97,7 @@ def confirm_changes(client, changeset):
 
 if __name__ == '__main__':
     import argparse
-    description = 'Download data from API.'
+    description = 'Upload data to the API.'
     parser = argparse.ArgumentParser(description=description)
     parser.add_argument(
         '-a', '--api',

--- a/webplatformcompat/parsers.py
+++ b/webplatformcompat/parsers.py
@@ -1,5 +1,6 @@
 from rest_framework_json_api.parsers import JsonApiParser \
     as BaseJsonApiParser
+from rest_framework_json_api.parsers import JsonApiMixin
 from rest_framework_json_api.utils import snakecase
 
 
@@ -9,3 +10,40 @@ class JsonApiParser(BaseJsonApiParser):
             return snakecase(model._meta.verbose_name_plural)
         else:
             return 'data'
+
+    def parse(self, stream, media_type=None, parser_context=None):
+        """Parse JSON API representation into DRF native format.
+
+        Same as rest_framework_json_api.parsers.JsonApiMixin.parse,
+        except that linked and meta sections are put into _view_extra
+        """
+        data = super(JsonApiMixin, self).parse(stream, media_type=media_type,
+                                               parser_context=parser_context)
+
+        view = parser_context.get("view", None)
+
+        model = self.model_from_obj(view)
+        resource_type = self.model_to_resource_type(model)
+
+        resource = {}
+
+        if resource_type in data:
+            resource = data[resource_type]
+
+        if isinstance(resource, list):  # pragma: nocover
+            resource = [self.convert_resource(r, view) for r in resource]
+        else:
+            resource = self.convert_resource(resource, view)
+
+        # Add extra data to _view_extra
+        # This should mirror .renderers.JsonApiRenderer.wrap_view_extra
+        view_extra = {}
+        if 'meta' in data:
+            view_extra['meta'] = data['meta']
+        if 'linked' in data:
+            assert 'meta' not in data['linked']
+            view_extra.update(data['linked'])
+        if view_extra:
+            resource['_view_extra'] = view_extra
+
+        return resource

--- a/webplatformcompat/serializers.py
+++ b/webplatformcompat/serializers.py
@@ -789,6 +789,14 @@ class FeatureExtra(object):
         """Commit changes to linked data"""
         self.changeset.change_original_collection()
 
+        # Adding sub-features will change the MPTT tree through direct SQL.
+        # Load the new tree data from the database before parent serializer
+        # overwrites it with old values.
+        tree_attrs = ['lft', 'rght', 'tree_id', 'level', 'parent']
+        db_feature = Feature.objects.only(*tree_attrs).get(id=self.feature.id)
+        for attr in tree_attrs:
+            setattr(self.feature, attr, getattr(db_feature, attr))
+
 
 class ViewFeatureExtraSerializer(ModelSerializer):
     """Linked resources and metadata for ViewFeatureSerializer."""

--- a/webplatformcompat/static/js/webplatformcompat.js
+++ b/webplatformcompat/static/js/webplatformcompat.js
@@ -57,6 +57,9 @@ window.WPC = {
         if (trans === null || trans === undefined) {
             return null;
         }
+        if (typeof trans === 'string') {
+            return "<code>" + trans + "</code>";
+        }
         if (trans.hasOwnProperty(lang)) {
             return trans[lang];
         }

--- a/webplatformcompat/static/js/webplatformcompat.js
+++ b/webplatformcompat/static/js/webplatformcompat.js
@@ -136,13 +136,14 @@ window.WPC = {
         return null;
     },
     generate_browser_tables: function (resources, lang) {
-        var idPrefix, tabs, tabCnt, tabIdx, tab, panel, tabList, tabContent,
-            tabListItem, tabContentItem, tabId, a, table, thead, tr, th,
-            browserCnt, browserIdx, browserId, browser, tbody, supportMap,
-            featureId, browserMap, feature, td, supports, supportCnt, supportIdx,
-            supportId, support, versionId, version, releaseUri, versionLink,
-            prefix, note, noteTxt, footnoteNum, footnoteId, footnote, backlink,
-            footnoteArray, footnoteDiv, footnoteCnt, footnoteIdx;
+        var a, backlink, browser, browserCnt, browserId, browserIdx,
+            browserMap, feature, featureId, footnote, footnoteArray,
+            footnoteCnt, footnoteDiv, footnoteId, footnoteIdx, footnoteNum,
+            footnoteSup, idPrefix, nosupport, note, noteTxt, panel, prefix,
+            releaseUri, span1, span2, support, supportCnt, supportId,
+            supportIdx, supportMap, supports, tab, tabCnt, tabContent,
+            tabContentItem, tabId, tabIdx, tabList, tabListItem, table, tabs,
+            tbody, td, th, thead, tr, unknown, version, versionId, versionLink;
         if (resources.meta.compat_table.tabs) {
             idPrefix = 'wpc-compat-' + resources.data.id;
             tabs = resources.meta.compat_table.tabs;
@@ -215,6 +216,20 @@ window.WPC = {
                         tr = document.createElement('tr');
                         td = document.createElement('td');
                         td.appendChild(this.trans_span(feature.name, lang));
+                        if (feature.experimental) {
+                            span1 = document.createElement('span');
+                            span1.setAttribute('class', 'glyphicon glyphicon-fire');
+                            span1.setAttribute('style', 'color: #09d;');
+                            span1.setAttribute('aria-hidden', 'true');
+                            span1.setAttribute('data-toggle', 'tooltip');
+                            span1.setAttribute('data-placement', 'top');
+                            span1.setAttribute('title', 'This is an experimental API that should not be used in production code.');
+                            span2 = document.createElement('span');
+                            span2.setAttribute('class', 'sr-only');
+                            span2.appendChild(document.createTextNode('This is an experimental API that should not be used in production code.'));
+                            td.appendChild(span1);
+                            td.appendChild(span2);
+                        }
                         tr.appendChild(td);
 
                         for (browserIdx = 0; browserIdx < browserCnt; browserIdx += 1) {
@@ -247,17 +262,21 @@ window.WPC = {
                                         } else {
                                             td.appendChild(document.createTextNode(version.version));
                                         }
-                                        if (support.support !== 'yes') {
-                                            td.appendChild(document.createTextNode(' (' + support.support + ')'));
-                                        }
-                                    } else {
-                                        td.appendChild(document.createTextNode('(' + support.support + ')'));
+                                    }
+                                    if (support.support === 'no') {
+                                        nosupport = document.createElement('span');
+                                        nosupport.setAttribute('style', 'color: #f00;');
+                                        nosupport.appendChild(document.createTextNode('Not supported'));
+                                        td.appendChild(nosupport);
+                                    } else if (support.support !== 'yes' || (!version.version)) {
+                                        td.appendChild(document.createTextNode(' (' + support.support + ')'));
                                     }
 
                                     // Prefix
                                     if (support.prefix && support.prefix_mandatory) {
                                         td.appendChild(document.createTextNode(' '));
                                         prefix = document.createElement('code');
+                                        prefix.setAttribute('style', 'white-space: nowrap;');
                                         prefix.appendChild(document.createTextNode(support.prefix));
                                         td.appendChild(prefix);
                                     } else {
@@ -280,17 +299,23 @@ window.WPC = {
                                         td.appendChild(document.createTextNode(' '));
                                         footnoteNum = resources.meta.compat_table.footnotes[supportId];
                                         footnoteId = 'wpc-compat-' + resources.data.id + '-footnote-' + footnoteNum;
+                                        footnoteSup = document.createElement('sup');
                                         footnote = document.createElement('a');
                                         footnote.setAttribute('id', footnoteId + '-back');
                                         footnote.setAttribute('href', '#' + footnoteId);
-                                        footnote.appendChild(document.createTextNode(footnoteNum));
-                                        td.appendChild(footnote);
+                                        footnote.appendChild(document.createTextNode("[" + footnoteNum + "]"));
+                                        footnoteSup.appendChild(footnote);
+                                        td.appendChild(footnoteSup);
                                     } else {
                                         footnote = null;
                                     }
                                 }
                             } else {
-                                td.appendChild(document.createTextNode('?'));
+                                unknown = document.createElement('span');
+                                unknown.setAttribute('style', 'color: rgb(255, 153, 0);');
+                                unknown.setAttribute('title', "Compatibility unknown; please update this.");
+                                unknown.appendChild(document.createTextNode('?'));
+                                td.appendChild(unknown);
                             }
                             tr.appendChild(td);
                         }

--- a/webplatformcompat/static/js/webplatformcompat.js
+++ b/webplatformcompat/static/js/webplatformcompat.js
@@ -230,6 +230,34 @@ window.WPC = {
                             td.appendChild(span1);
                             td.appendChild(span2);
                         }
+                        if (!feature.standardized) {
+                            span1 = document.createElement('span');
+                            span1.setAttribute('class', 'glyphicon glyphicon-warning-sign');
+                            span1.setAttribute('style', 'color: #db0;');
+                            span1.setAttribute('aria-hidden', 'true');
+                            span1.setAttribute('data-toggle', 'tooltip');
+                            span1.setAttribute('data-placement', 'top');
+                            span1.setAttribute('title', 'This API has not been standardized.');
+                            span2 = document.createElement('span');
+                            span2.setAttribute('class', 'sr-only');
+                            span2.appendChild(document.createTextNode('This API has not been standardized.'));
+                            td.appendChild(span1);
+                            td.appendChild(span2);
+                        }
+                        if (feature.obsolete) {
+                            span1 = document.createElement('span');
+                            span1.setAttribute('class', 'glyphicon glyphicon-thumbs-down');
+                            span1.setAttribute('style', 'color: #000;');
+                            span1.setAttribute('aria-hidden', 'true');
+                            span1.setAttribute('data-toggle', 'tooltip');
+                            span1.setAttribute('data-placement', 'top');
+                            span1.setAttribute('title', 'This deprecated API should no longer be used, but will probably still work.');
+                            span2 = document.createElement('span');
+                            span2.setAttribute('class', 'sr-only');
+                            span2.appendChild(document.createTextNode('This deprecated API should no longer be used, but will probably still work.'));
+                            td.appendChild(span1);
+                            td.appendChild(span2);
+                        }
                         tr.appendChild(td);
 
                         for (browserIdx = 0; browserIdx < browserCnt; browserIdx += 1) {
@@ -264,6 +292,9 @@ window.WPC = {
                                         }
                                     }
                                     if (support.support === 'no') {
+                                        if (version.version) {
+                                            td.appendChild(document.createTextNode(' '));
+                                        }
                                         nosupport = document.createElement('span');
                                         nosupport.setAttribute('style', 'color: #f00;');
                                         nosupport.appendChild(document.createTextNode('Not supported'));

--- a/webplatformcompat/templates/webplatformcompat/base.jinja2
+++ b/webplatformcompat/templates/webplatformcompat/base.jinja2
@@ -18,11 +18,23 @@
     {%- block head_extra %}{% endblock %}
   </head>
   <body>
-    {% block body_container -%}
+    {% block pre_body_container %}{% endblock %}
+    {%- block body_container -%}
     <div class="container">
         {% block body_title_elem -%}
         <h1 id="body_title">{% block body_title %}TODO: set block body_title{% endblock %}</h1>
         {%- endblock body_title_elem %}
+        {% block quick_nav %}{% endblock %}
+        {% block messages %}
+          {% if messages %}
+            {% for message in messages %}
+            <div class="alert alert-{{message.tags}} alert-dismissible fade in" role="alert">
+              <button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+            {{message}}
+            </div>
+            {% endfor %}
+          {% endif %}
+        {% endblock messages %}
         {% block content %}{% endblock %}
         <hr>
         <footer>

--- a/webplatformcompat/templates/webplatformcompat/feature.basic.jinja2
+++ b/webplatformcompat/templates/webplatformcompat/feature.basic.jinja2
@@ -43,7 +43,7 @@
 <i>No specifications</i>
 {% endif %}
 
-<h2>Browser compatability</h2>
+<h2>Browser compatibility</h2>
 {%- for tab in meta['compat_table']['tabs'] %}
 
 
@@ -120,7 +120,7 @@
   </tbody>
 </table>
 {%- else %}
-<i>No compatability data</i>
+<i>No compatibility data</i>
 
 {%- endfor %}
 

--- a/webplatformcompat/templates/webplatformcompat/feature.js.jinja2
+++ b/webplatformcompat/templates/webplatformcompat/feature.js.jinja2
@@ -19,7 +19,7 @@
   <p><i>Loading...</i></p>
 </div>
 
-<h2>Browser compatability</h2>
+<h2>Browser compatibility</h2>
 <div id="wpc_tables">
   <p><i>Loading...</i></p>
 </div>

--- a/webplatformcompat/templates/webplatformcompat/home.jinja2
+++ b/webplatformcompat/templates/webplatformcompat/home.jinja2
@@ -18,25 +18,28 @@
 
 <div class="container">
   <div class="row">
-    <div class="col-md-4">
+    <div class="col-md-3">
       <h2>Explore the API</h2>
       <p>Jump right into the self-documenting API.</p>
-      <p><a class="btn btn-default" href="/api/v1/" role="button">API »</a></p>
+      <p><a class="btn btn-default" href="/api/v1/" role="button">API &raquo;</a></p>
     </div>
-    <div class="col-md-4">
+    <div class="col-md-3">
       <h2>Browse the Data</h2>
       <p>View the web platform compatibility data available from the API.</p>
-      <p><a class="btn btn-default" href="{{ url('browse') }}" role="button">Data »</a></p>
+      <p><a class="btn btn-default" href="{{ url('browse') }}" role="button">Data &raquo;</a></p>
     </div>
-    <div class="col-md-4">
+    <div class="col-md-3">
+      <h2>Import from MDN</h2>
+      <p>See the current status of the importer on your favorite MDN page.</p>
+      <p><a class="btn btn-default" href="{{ url('feature_page_list') }}" role="button">Importer &raquo;</a></p>
+    </div>
+    <div class="col-md-3">
       <h2>Read the Docs</h2>
       <p>Read the detailed API documentation to build your own API client.</p>
-      <p><a class="btn btn-default" href="http://web-platform-compat.readthedocs.org/en/latest/" role="button">Documentation »</a></p>
+      <p><a class="btn btn-default" href="http://web-platform-compat.readthedocs.org/en/latest/" role="button">Documentation &raquo;</a></p>
     </div>
   </div>
-
   <hr>
-
   <footer>
     <p>© Mozilla 2014</p>
   </footer>

--- a/webplatformcompat/templates/webplatformcompat/home.jinja2
+++ b/webplatformcompat/templates/webplatformcompat/home.jinja2
@@ -7,7 +7,7 @@
   <div class="container">
     <h1 class="smaller">Welcome to the Web Platform Compatibility API</h1>
     <p>
-        The Web Platform Compatibility API will support compatability data
+        The Web Platform Compatibility API will support compatibility data
         on the Mozilla Developer Network. This currently takes the form of
         browser compatibility tables, such as the one on the CSS display
         property. The API will help centralize this data, and allow it to be

--- a/webplatformcompat/tests/test_viewset_viewfeatureset.py
+++ b/webplatformcompat/tests/test_viewset_viewfeatureset.py
@@ -1806,6 +1806,7 @@ class TestViewFeatureUpdates(APITestCase):
         self.assertEqual(subfeature.parent, self.feature)
         feature = Feature.objects.get(id=self.feature.id)
         self.assertEqual(list(feature.children.all()), [subfeature])
+        self.assertEqual(list(feature.get_descendants()), [subfeature])
 
     def test_post_add_second_subfeature(self):
         sf1 = self.create(

--- a/webplatformcompat/tests/test_viewset_viewfeatureset.py
+++ b/webplatformcompat/tests/test_viewset_viewfeatureset.py
@@ -1637,7 +1637,7 @@ multipage/sections.html#the-address-element">
   </tbody>
 </table>
 
-<h2>Browser compatability</h2>
+<h2>Browser compatibility</h2>
 
 <h3>Desktop Browsers</h3>
 <table class="compat-table">

--- a/webplatformcompat/tests/test_viewset_viewfeatureset.py
+++ b/webplatformcompat/tests/test_viewset_viewfeatureset.py
@@ -1736,7 +1736,8 @@ class TestViewFeatureUpdates(APITestCase):
         self.browser = self.create(
             Browser, slug='browser', name={'en': 'Browser'})
         self.version = self.create(
-            Version, browser=self.browser, version='1.0')
+            Version, browser=self.browser, version='1.0',
+            release_day='2015-02-17')
         self.maturity = self.create(Maturity, slug='M', name={"en": 'Mature'})
         self.spec = self.create(
             Specification, slug='spec', mdn_key='SPEC', name={'en': 'Spec'},
@@ -1748,7 +1749,7 @@ class TestViewFeatureUpdates(APITestCase):
             "links": {"versions": [str(self.version.id)]}}
         self.version_data = {
             "id": str(self.version.id), "version": self.version.version,
-            "release_day": None, "retirement_day": None, "note": None,
+            "release_day": '2015-02-17', "retirement_day": None, "note": None,
             "status": "unknown", "release_notes_uri": None,
             "links": {"browser": str(self.browser.id)}}
         self.maturity_data = {
@@ -2082,30 +2083,6 @@ class TestViewFeatureUpdates(APITestCase):
                 "detail": (
                     'Resource can not be created as part of this update.'
                     ' Create first, and try again.'),
-            }]
-        }
-        actual_error = loads(response.content.decode('utf-8'))
-        self.assertEqual(expected_error, actual_error)
-
-    def test_omitted_specification_field_is_error(self):
-        section_data = {
-            "id": "_section", "name": {"en": "Section"},
-            "links": {
-                "specification": str(self.spec.id),
-                "features": [str(self.feature.id)],
-            }}
-        spec_data = self.spec_data.copy()
-        del spec_data['links']['sections']
-        json_data = self.json_api(
-            {'sections': ['_section']}, sections=[section_data],
-            specifications=[spec_data], maturities=[self.maturity_data])
-        response = self.client.put(
-            self.url, data=json_data, content_type="application/vnd.api+json")
-        self.assertEqual(response.status_code, 400, response.content)
-        expected_error = {
-            'errors': [{
-                "status": "400", "path": "/linked.specifications.0.sections",
-                "detail": 'Field was omitted, but should be set to []'
             }]
         }
         actual_error = loads(response.content.decode('utf-8'))

--- a/webplatformcompat/urls.py
+++ b/webplatformcompat/urls.py
@@ -1,5 +1,6 @@
 from django.conf.urls import include, patterns, url
 from django.views.generic.base import RedirectView
+from mdn.urls import mdn_urlpatterns
 from webplatformcompat.routers import router
 
 from .views import RequestView, ViewFeature
@@ -17,6 +18,9 @@ webplatformcompat_urlpatterns = patterns(
         namespace='rest_framework')),
     url(r'^api/$', RedirectView.as_view(url='/api/v1/', permanent=False)),
     url(r'^api/v1/', include(router.urls)),
+    url(r'^importer$', RedirectView.as_view(
+        url='/importer/', permanent=False)),
+    url(r'^importer/', include(mdn_urlpatterns)),
     url(r'^view_feature/(?P<feature_id>\d+)(.html)?$', ViewFeature.as_view(
         template_name='webplatformcompat/feature.js.jinja2'),
         name='view_feature'),

--- a/webplatformcompat/viewsets.py
+++ b/webplatformcompat/viewsets.py
@@ -1,8 +1,9 @@
 # -*- coding: utf-8 -*-
 
 from django.contrib.auth.models import User
-from rest_framework.renderers import BrowsableAPIRenderer
+from rest_framework.mixins import UpdateModelMixin
 from rest_framework.parsers import FormParser, MultiPartParser
+from rest_framework.renderers import BrowsableAPIRenderer
 from rest_framework.viewsets import ModelViewSet as BaseModelViewSet
 from rest_framework.viewsets import ReadOnlyModelViewSet as BaseROModelViewSet
 
@@ -170,10 +171,13 @@ class HistoricalVersionViewSet(ReadOnlyModelViewSet):
 # Views
 #
 
-class ViewFeaturesViewSet(CachedViewMixin, ReadOnlyModelViewSet):
+class ViewFeaturesViewSet(
+        PartialPutMixin, CachedViewMixin, UpdateModelMixin,
+        ReadOnlyModelViewSet):
     model = Feature
     serializer_class = ViewFeatureSerializer
     filter_fields = ('slug',)
+    parser_classes = (JsonApiParser, FormParser, MultiPartParser)
     renderer_classes = (
         JsonApiRenderer, BrowsableAPIRenderer, JsonApiTemplateHTMLRenderer)
     template_name = 'webplatformcompat/feature.basic.jinja2'

--- a/wpcsite/settings.py
+++ b/wpcsite/settings.py
@@ -27,6 +27,8 @@ ALLOWED_HOSTS - comma-separated list of allowed hosts
 DATABASE_URL - See https://github.com/kennethreitz/dj-database-url
 DJANGO_DEBUG - 1 to enable, 0 to disable, default disabled
 EXTRA_INSTALLED_APPS - comma-separated list of apps to add to INSTALLED_APPS
+MDN_ALLOWED_URL_PREFIXES - comma-separated list of URL prefixes allowed by
+  the scraper
 MEMCACHE_SERVERS - semicolon-separated list of memcache servers
 MEMCACHE_USERNAME - username for memcache servers
 MEMCACHE_PASSWORD - password for memcache servers
@@ -88,6 +90,7 @@ INSTALLED_APPS = [
     'rest_framework',
     'sortedm2m',
 
+    'mdn',
     'webplatformcompat',
 ]
 if environ.get('EXTRA_INSTALLED_APPS'):
@@ -188,6 +191,16 @@ SESSION_ENGINE = "django.contrib.sessions.backends.cached_db"
 
 # When the number of descendants means to paginate a view_feature
 PAGINATE_VIEW_FEATURE = 50
+
+# Authentication
+LOGIN_URL = '/api-auth/login/'
+
+# MDN Scraping
+if environ.get('MDN_ALLOWED_URL_PREFIXES') and not TESTING:
+    raw = environ['MDN_ALLOWED_URL_PREFIXES']
+    MDN_ALLOWED_URLS = tuple(raw.split(','))
+else:
+    MDN_ALLOWED_URLS = ('https://developer.mozilla.org/en-US/docs/', )
 
 #
 # 3rd Party Libraries


### PR DESCRIPTION
This PR adds the ability to import some data from MDN pages into the API, fixing [bug 1079920](https://bugzilla.mozilla.org/show_bug.cgi?id=1079920).  A live version is at https://browsercompat.herokuapp.com.  It includes:

* A new app ``mdn``, for data and code specific to the import effort and working with MDN
  - DB models for storing MDN page contents and metadata
  - A Parsing Expression Grammer (PEG) for extracting data from an MDN page
  - Code to match features in MDN pages to existing API resources
  - Serve scraped data in a format similar to the `view_feature` API response
  - An interface to view scraped data and parsing issues, to refresh the cached MDN content, and to re-run the parser
* Add PUT method to `view_feature` detail view to allow bulk updating of feature data for one MDN page (currently restricted to superuser).
* A command-line tool `import_mdn.py` to initialize or refresh scraping for all known MDN feature pages
* A command-line tool `gather_import_errors.py` to collect and summarize import errors
* ``s/compatability/compatibility/g``

This is a complete first pass, but there are additional tasks, such as the next round of parser improvements, tracked in [bug 1132269](https://bugzilla.mozilla.org/show_bug.cgi?id=1132269).

