### PR TITLE
fix bug 1170199 - detect pages with no data

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -8,6 +8,7 @@ source =
     webplatformcompat
 omit =
     tools/client.py
+    tools/common.py
     tools/download_data.py
     tools/gather_import_issues.py
     tools/import_mdn.py

--- a/.coveragerc
+++ b/.coveragerc
@@ -9,7 +9,7 @@ source =
 omit =
     tools/client.py
     tools/download_data.py
-    tools/gather_import_errors.py
+    tools/gather_import_issues.py
     tools/import_mdn.py
     tools/integration_requests.py
     tools/load_spec_data.py

--- a/.coveragerc
+++ b/.coveragerc
@@ -15,6 +15,7 @@ omit =
     tools/integration_requests.py
     tools/load_spec_data.py
     tools/load_webcompat_data.py
+    tools/mirror_mdn_features.py
     tools/sample_mdn.py
     tools/sync_from_api.py
     tools/upload_data.py

--- a/docs/draft/resources.rst
+++ b/docs/draft/resources.rst
@@ -313,8 +313,9 @@ The **features** representation includes:
     - **id** *(server selected)* - Database ID
     - **slug** *(write-once)* - Unique, human-friendly slug
     - **mdn_uri** *(optional, localized)* - The URI of the language-specific
-      MDN page that this feature was first scraped from.  May be used in UX or
-      for debugging import scripts.
+      MDN page that this feature was first scraped from.  If the path contains
+      unicode, it should be percent-encoded as in `RFC 3987`_. May be used in
+      UX or for debugging import scripts.
     - **experimental** - True if a feature is considered experimental, such as
       being non-standard or part of an non-ratified spec.
     - **standardized** - True if a feature is described in a standards-track
@@ -556,5 +557,6 @@ A sample response is:
 .. _non-linguistic: http://www.w3.org/International/questions/qa-no-language#nonlinguistic
 .. _`ISO 8601`: http://en.wikipedia.org/wiki/ISO_8601
 .. _MDN: https://developer.mozilla.org
+.. _RFC 3987: http://tools.ietf.org/html/rfc3987.html#section-3.1
 .. _SpecName: https://developer.mozilla.org/en-US/docs/Template:SpecName
 .. _Spec2: https://developer.mozilla.org/en-US/docs/Template:Spec2

--- a/docs/tools.rst
+++ b/docs/tools.rst
@@ -100,6 +100,24 @@ tools/run_integration_tests.sh. Usage::
 * ``-q``: Be quieter
 * ``case name``: Run the listed cases, not the full suite of cases
 
+mirror_mdn_features.py
+----------------------
+Create and update API features for MDN pages.  This will create the branch
+features, and then import_mdn.py can be used to generate the leaf features.
+Usage::
+
+    $ tools/mirror_mdn_features.py [--api API] [--data DATA]
+                                   [--user USER] [--password PASSWORD]
+
+* ``--api API`` `(optional)`: Set the base URL of the API
+  (default: ``http://localhost:8000``)
+* ``--user USER``: Set the username to use for requests (default is prompt for
+  username)
+* ``--password PASSWORD``: Set the password to use for requests (default is
+  prompt for username)
+* ``--data DATA``: Set the data folder for caching MDN page JSON
+
+
 run_integration_tests.sh
 ------------------------
 Run a local API server with known data, make requests against it, and look for

--- a/mdn/admin.py
+++ b/mdn/admin.py
@@ -3,7 +3,20 @@ from django.contrib import admin
 
 from .models import Issue, FeaturePage, PageMeta, TranslatedContent
 
-admin.site.register(Issue)
-admin.site.register(FeaturePage)
-admin.site.register(PageMeta)
-admin.site.register(TranslatedContent)
+
+class IssueAdmin(admin.ModelAdmin):
+    readonly_fields = ('page', 'content')
+
+
+class FeaturePageAdmin(admin.ModelAdmin):
+    readonly_fields = ('feature',)
+
+
+class ContentAdmin(admin.ModelAdmin):
+    readonly_fields = ('page',)
+
+
+admin.site.register(Issue, IssueAdmin)
+admin.site.register(FeaturePage, FeaturePageAdmin)
+admin.site.register(PageMeta, ContentAdmin)
+admin.site.register(TranslatedContent, ContentAdmin)

--- a/mdn/admin.py
+++ b/mdn/admin.py
@@ -1,8 +1,9 @@
 """Admin interface for mdn app."""
 from django.contrib import admin
 
-from .models import FeaturePage, PageMeta, TranslatedContent
+from .models import Issue, FeaturePage, PageMeta, TranslatedContent
 
+admin.site.register(Issue)
 admin.site.register(FeaturePage)
 admin.site.register(PageMeta)
 admin.site.register(TranslatedContent)

--- a/mdn/migrations/0003_add_issues_table.py
+++ b/mdn/migrations/0003_add_issues_table.py
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*-
+# flake8: noqa
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+import django_extensions.db.fields.json
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('mdn', '0002_data_add_group'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='Issue',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('slug', models.SlugField(help_text='Human-friendly slug for issue.', choices=[('false_start', 'false_start'), ('bad_json', 'bad_json'), ('halt_import', 'halt_import'), ('section_missed', 'section_missed'), ('spec_hERROR_id', 'spec_hERROR_id'), ('failed_download', 'failed_download'), ('unknown_kumascript', 'unknown_kumascript'), ('unknown_spec', 'unknown_spec'), ('spec_hERROR_name', 'spec_hERROR_name'), ('inline_text', 'inline_text'), ('footnote_multiple', 'footnote_multiple'), ('footnote_missing', 'footnote_missing'), ('footnote_feature', 'footnote_feature'), ('unknown_browser', 'unknown_browser'), ('extra_cell', 'extra_cell'), ('unknown_version', 'unknown_version'), ('spec_mismatch', 'spec_mismatch'), ('footnote_unused', 'footnote_unused'), ('exception', 'exception'), ('section_skipped', 'section_skipped'), ('compatgeckodesktop_unknown', 'compatgeckodesktop_unknown'), ('compatgeckofxos_unknown', 'compatgeckofxos_unknown'), ('footnote_no_id', 'footnote_no_id'), ('nested_p', 'nested_p'), ('compatgeckofxos_override', 'compatgeckofxos_override')])),
+                ('start', models.IntegerField(help_text='Start position in source text')),
+                ('end', models.IntegerField(help_text='End position in source text')),
+                ('params', django_extensions.db.fields.json.JSONField(help_text='Parameters for description templates')),
+                ('content', models.ForeignKey(blank=True, to='mdn.TranslatedContent', help_text='Content the issue was found on', null=True)),
+                ('page', models.ForeignKey(related_name='issues', to='mdn.FeaturePage')),
+            ],
+            options={
+            },
+            bases=(models.Model,),
+        ),
+        migrations.RemoveField(
+            model_name='featurepage',
+            name='has_issues',
+        ),
+    ]

--- a/mdn/migrations/0004_expand_url.py
+++ b/mdn/migrations/0004_expand_url.py
@@ -1,0 +1,46 @@
+# -*- coding: utf-8 -*-
+# flake8: noqa
+
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('mdn', '0003_add_issues_table'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='translatedcontent',
+            name='title',
+            field=models.TextField(help_text='Page title in locale', blank=True),
+            preserve_default=True,
+        ),
+        migrations.AlterField(
+            model_name='featurepage',
+            name='status',
+            field=models.IntegerField(default=0, help_text='Status of MDN Parsing process', choices=[(0, 'Starting Import'), (1, 'Fetching Metadata'), (2, 'Fetching MDN pages'), (3, 'Parsing MDN pages'), (4, 'Parsing Complete'), (5, 'Scraping Failed'), (6, 'No Compat Data')]),
+            preserve_default=True,
+        ),
+        migrations.AlterField(
+            model_name='issue',
+            name='slug',
+            field=models.SlugField(help_text='Human-friendly slug for issue.', choices=[('false_start', 'false_start'), ('bad_json', 'bad_json'), ('feature_header', 'feature_header'), ('section_missed', 'section_missed'), ('halt_import', 'halt_import'), ('failed_download', 'failed_download'), ('unexpected_attribute', 'unexpected_attribute'), ('unknown_spec', 'unknown_spec'), ('spec_h2_id', 'spec_h2_id'), ('spec2_arg_count', 'spec2_arg_count'), ('spec_h2_name', 'spec_h2_name'), ('inline_text', 'inline_text'), ('footnote_multiple', 'footnote_multiple'), ('footnote_missing', 'footnote_missing'), ('footnote_feature', 'footnote_feature'), ('unknown_browser', 'unknown_browser'), ('doc_parse_error', 'doc_parse_error'), ('extra_cell', 'extra_cell'), ('unknown_version', 'unknown_version'), ('spec2_wrong_kumascript', 'spec2_wrong_kumascript'), ('spec_mismatch', 'spec_mismatch'), ('footnote_unused', 'footnote_unused'), ('specname_blank_key', 'specname_blank_key'), ('exception', 'exception'), ('section_skipped', 'section_skipped'), ('compatgeckodesktop_unknown', 'compatgeckodesktop_unknown'), ('compatgeckofxos_unknown', 'compatgeckofxos_unknown'), ('footnote_no_id', 'footnote_no_id'), ('nested_p', 'nested_p'), ('unknown_kumascript', 'unknown_kumascript'), ('compatgeckofxos_override', 'compatgeckofxos_override')]),
+            preserve_default=True,
+        ),
+        migrations.AlterField(
+            model_name='pagemeta',
+            name='path',
+            field=models.CharField(help_text='Path of MDN page', max_length=1024),
+            preserve_default=True,
+        ),
+        migrations.AlterField(
+            model_name='translatedcontent',
+            name='path',
+            field=models.CharField(help_text='Path of MDN page', max_length=1024),
+            preserve_default=True,
+        ),
+    ]

--- a/mdn/models.py
+++ b/mdn/models.py
@@ -145,6 +145,8 @@ class FeaturePage(models.Model):
         for t in self.translations():
             if t.locale != 'en-US':
                 feature['mdn_uri'][t.locale] = t.url()
+        if ['zxx'] == list(feature['name'].keys()):
+            feature['name'] = feature['name']['zxx']
 
         view_feature = OrderedDict((
             ('features', feature),

--- a/mdn/models.py
+++ b/mdn/models.py
@@ -510,6 +510,8 @@ class Issue(models.Model):
             return ''
 
         raw = self.content.raw
+        if not raw.endswith('\n'):
+            raw += '\n'
         start_line = raw.count('\n', 0, self.start)
         end_line = raw.count('\n', 0, self.end)
         ctx_start_line = max(0, start_line - 2)
@@ -535,7 +537,7 @@ class Issue(models.Model):
 
         out = []
         for num, (line, err_line) in enumerate(zip(context_lines, err_lines)):
-            lnum = ctx_start_line + num
+            lnum = ctx_start_line + num + 1
             out.append(
                 text_type(lnum).rjust(digits) + ' ' + line)
             if '^' in err_line:

--- a/mdn/models.py
+++ b/mdn/models.py
@@ -383,6 +383,16 @@ ISSUES = {
         ERROR,
         'KumaScript SpecName has a blank key',
         'Update the MDN page to include a valid mdn_key'),
+    'specname_converted': (
+        WARNING,
+        'Specification name should be converted to KumaScript',
+        'The specification "{original}" should be replaced with the KumaScript'
+        ' {{{{SpecName({key})}}}}'),
+    'specname_not_kumascript': (
+        ERROR,
+        'Specification name unknown, and should be converted to KumaScript',
+        'Expected KumaScript {{{{SpecName(key, subpath, name)}}}}, but got'
+        ' text "{original}".'),
     'spec2_wrong_kumascript': (
         ERROR,
         'Expected KumaScript Spec2(), got {kumascript}',

--- a/mdn/models.py
+++ b/mdn/models.py
@@ -9,10 +9,11 @@ from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.db import models
 from django.utils.encoding import python_2_unicode_compatible
-from django.utils.html import escape
+from django.utils.six import text_type
 from django.utils.six.moves.urllib_parse import urlparse
 from django.utils.timesince import timesince
 from django_extensions.db.fields import ModificationDateTimeField
+from django_extensions.db.fields.json import JSONField
 
 from webplatformcompat.models import Feature
 
@@ -60,8 +61,6 @@ class FeaturePage(models.Model):
     modified = ModificationDateTimeField(
         help_text="Last modification time", db_index=True)
     raw_data = models.TextField(help_text="JSON-encoded parsed content")
-    has_issues = models.BooleanField(
-        help_text="Issues found when parsing the page", default=False)
 
     def __str__(self):
         return "%s for %s" % (self.get_status_display(), self.slug())
@@ -112,6 +111,7 @@ class FeaturePage(models.Model):
         drop_cache - Delete cached MDN content
         """
         self.status = FeaturePage.STATUS_STARTING
+        self.issues.all().delete()
         self.reset_data()
         self.save()
         meta = self.meta()
@@ -165,11 +165,10 @@ class FeaturePage(models.Model):
                 ))),
                 ("scrape", OrderedDict((
                     ("phase", "Starting Import"),
-                    ("errors", []),
+                    ("issues", []),
                     ("raw", None)))))))))
 
         self.data = view_feature
-        self.has_issues = False
         return view_feature
 
     @property
@@ -181,6 +180,14 @@ class FeaturePage(models.Model):
             data = {}
         if not data:
             data = self.reset_data()
+
+        # Add issues
+        issues = []
+        for issue in self.issues.order_by('id'):
+            issues.append([
+                issue.slug, issue.start, issue.end, issue.params])
+        data['meta']['scrape']['issues'] = issues
+
         return data
 
     @data.setter
@@ -188,22 +195,287 @@ class FeaturePage(models.Model):
         """Serialize the data for storage"""
         self.raw_data = dumps(value, indent=2)
 
-    def add_error(self, error, safe=False):
-        """Add an error to the JSON data"""
-        data = self.data
-        errors = data['meta']['scrape']['errors']
-        if safe:
-            err = error
+    @property
+    def has_issues(self):
+        return self.issues.exists()
+
+    @property
+    def issue_counts(self):
+        if not getattr(self, '_issue_counts', None):
+            self._issue_counts = {WARNING: 0, ERROR: 0, CRITICAL: 0}
+            for issue in self.issues.all():
+                self._issue_counts[issue.severity] += 1
+        return self._issue_counts
+
+    @property
+    def warnings(self):
+        return self.issue_counts[WARNING]
+
+    @property
+    def errors(self):
+        return self.issue_counts[ERROR]
+
+    @property
+    def critical(self):
+        return self.issue_counts[CRITICAL]
+
+    def add_issue(self, issue, locale=None):
+        """Add an issue to the page."""
+        slug, start, end, params = issue
+        if locale:
+            content = self.translatedcontent_set.get(locale=locale)
         else:
-            err = '<pre>%s</pre>' % escape(error)
-        if err not in errors:
-            errors.append(err)
-        self.data = data
-        self.has_issues = True
+            content = None
+
+        # Did we already add this issue?
+        if self.issues.filter(slug=slug, start=start, end=end).exists():
+            raise ValueError("Duplicate issue")
+        self.issues.create(
+            slug=slug, start=start, end=end, params=params, content=content)
+        self._issue_counts = None
 
     @models.permalink
     def get_absolute_url(self):
         return ('mdn.views.feature_page_detail', [str(self.id)])
+
+# Issue severity
+WARNING = 1
+ERROR = 2
+CRITICAL = 3
+SEVERITIES = {
+    WARNING: 'Warning',
+    ERROR: 'Error',
+    CRITICAL: 'Critical',
+}
+
+# Issue slugs, severity, brief templates, and long templates
+# This was a database model, but it was cumbersome to update text with a
+#  database migration, and changing slugs require code changes as well.
+ISSUES = {
+    'bad_json': (
+        CRITICAL,
+        'Response from {url} is not JSON',
+        'Actual content:\n{content}'),
+    'compatgeckodesktop_unknown': (
+        ERROR,
+        'Unknown Gecko version "{version}"',
+        'The importer does not recognize this version for CompatGeckoDesktop.'
+        ' Change the MDN page or update the importer.'),
+    'compatgeckofxos_override': (
+        ERROR,
+        'Override "{override}" is invalid for Gecko version "{version}".',
+        'The importer does not recognize this override for CompatGeckoFxOS.'
+        ' Change the MDN page or update the importer.'),
+    'compatgeckofxos_unknown': (
+        ERROR,
+        'Unknown Gecko version "{version}"',
+        'The importer does not recognize this version for CompatGeckoFxOS.'
+        ' Change the MDN page or update the importer.'),
+    'exception': (CRITICAL, 'Unhandled exception', '{traceback}'),
+    'extra_cell': (
+        ERROR,
+        'Extra cell in compatibility table row.',
+        'A row in the compatibility table has more cells than the header'
+        ' row. It may be the cell identified in the context, a different'
+        ' cell in the row, or a missing header cell.'),
+    'failed_download': (
+        CRITICAL, 'Failed to download {url}.',
+        'Status {status}, Content:\n{text}'),
+    'false_start': (
+        CRITICAL,
+        'No <h2> found in page.',
+        'A compatibility table must be after a proper <h2> to be imported.'),
+    'feature_header': (
+        WARNING,
+        'Expected first header to be "Feature"',
+        'The first header is "{header}", not "Feature"'),
+    'footnote_feature': (
+        ERROR,
+        'Footnotes are not allowed on features',
+        'The Feature model does not include a notes field. Remove the'
+        ' footnote from the feature.'),
+    'footnote_missing': (
+        ERROR,
+        'Footnote [{footnote_id}] not found.',
+        'The compatibility table has a reference to footnote'
+        ' "{footnote_id}", but no matching footnote was found. This may'
+        ' be due to parse issues in the footnotes section, a typo in the MDN'
+        ' page, or a footnote that was removed without removing the footnote'
+        ' reference from the table.'),
+    'footnote_multiple': (
+        ERROR,
+        'Only one footnote allowed per compatibility cell.',
+        'The API supports only one footnote per support assertion. Combine'
+        ' footnotes [{prev_footnote_id}] and [{footnote_id}], or remove'
+        ' one of them.'),
+    'footnote_no_id': (
+        ERROR,
+        'Footnote has no ID.',
+        'Footnote references, such as [1], are used to link the footnote to'
+        ' the support assertion in the compatibility table. Reformat the MDN'
+        ' page to use footnote references.'),
+    'footnote_unused': (
+        ERROR,
+        'Footnote [{footnote_id}] is unused.',
+        'No cells in the compatibility table included the footnote reference'
+        ' [{footnote_id}]. This could be due to a issue importing the'
+        ' compatibility cell, a typo on the MDN page, or an extra footnote'
+        ' that should be removed from the MDN page.'),
+    'halt_import': (
+        CRITICAL,
+        'Unable to finish importing MDN page.',
+        'The importer was unable to finish parsing the MDN page. This may be'
+        ' due to a duplicated section, or other unexpected content.'),
+    'inline_text': (
+        ERROR,
+        'Unknown inline support text "{text}".',
+        'The API schema does not include inline notes. This text needs to be'
+        ' converted to a footnote, converted to a support attribute (which'
+        ' may require an importer update), or removed.'),
+    'nested_p': (
+        ERROR,
+        'Nested <p> tags are not supported.',
+        'Edit the MDN page to remove the nested <p> tag'),
+    'section_skipped': (
+        CRITICAL,
+        'Section <h2>{title}</h2> has unexpected content.',
+        'The parser was trying to match rule "{rule_name}", but was unable to'
+        ' understand some unexpected content. This may be markup or'
+        ' text, or a side-effect of previous issues. Look closely at the'
+        ' context (as well as any previous issues) to find the problem'
+        ' content.'),
+    'section_missed': (
+        CRITICAL,
+        'Section <h2>{title}</h2> was not imported.',
+        'The import of section {title} failed, but no parse error was'
+        ' detected. This is usually because of a previous critical error,'
+        ' which must be cleared before any parsing can be attempted.'),
+    'spec_h2_id': (
+        WARNING,
+        'Expected <h2 id="Specifications">, actual id={{h2_id}}',
+        'Fix the id so that the table of contents, other feature work.'),
+    'spec_h2_name': (
+        WARNING,
+        'Expected <h2 name="Specifications">, actual name={{h2_name}}',
+        'Fix or remove the name attribute.'),
+    'spec_mismatch': (
+        ERROR,
+        'SpecName({specname_key}, ...) does not match'
+        ' Spec2({spec2_key}).',
+        'SpecName and Spec2 must refer to the same mdn_key. Update the MDN'
+        ' page.'),
+    'unexpected_attribute': (
+        WARNING,
+        'Unexpected attribute <{node_type} {ident}="{value}">',
+        'For <{node_type}>, the importer is ready for the attributes'
+        ' {expected}. This unexpected attribute will be discarded.'),
+    'unknown_browser': (
+        ERROR,
+        'Unknown Browser "{name}".',
+        'The API does not have a browser with the name "{name}".'
+        ' This could be a typo on the MDN page, or the browser needs to'
+        ' be added to the API.'),
+    'unknown_kumascript': (
+        ERROR,
+        'Unknown KumaScript {display} in {scope}.',
+        'The importer has to run custom code to import KumaScript, and it'
+        ' hasn\'t been taught how to import {name} when it appears in a'
+        ' {scope}. File a bug, or convert the MDN page to not use this'
+        ' KumaScript macro.'),
+    'unknown_spec': (
+        ERROR,
+        'Unknown Specification "{key}".',
+        'The API does not have a specification with mdn_key "{key}".'
+        ' This could be a typo on the MDN page, or the specfication needs to'
+        ' be added to the API.'),
+    'unknown_version': (
+        ERROR,
+        'Unknown version "{version}" for browser "{browser_name}"',
+        'The API does not have the version "{version}" for browser'
+        ' "{browser_name}" (id {browser_id}, slug "{browser_slug}").'
+        ' This could be a typo on the MDN page, or the version needs to'
+        ' be added to the API.'),
+}
+
+
+@python_2_unicode_compatible
+class Issue(models.Model):
+    """An issue on a FeaturePage."""
+    page = models.ForeignKey(FeaturePage, related_name='issues')
+    slug = models.SlugField(
+        help_text="Human-friendly slug for issue.",
+        choices=[(slug, slug) for slug in ISSUES])
+    start = models.IntegerField(
+        help_text="Start position in source text")
+    end = models.IntegerField(
+        help_text="End position in source text")
+    params = JSONField(
+        help_text="Parameters for description templates")
+    content = models.ForeignKey(
+        'TranslatedContent', null=True, blank=True,
+        help_text="Content the issue was found on")
+
+    def __str__(self):
+        if self.content:
+            url = self.content.url()
+        else:
+            url = self.page.url
+        return "{slug} [{start}:{end}] on {url}".format(
+            slug=self.slug, start=self.start, end=self.end, url=url)
+
+    @property
+    def severity(self):
+        return ISSUES[self.slug][0]
+
+    @property
+    def brief_description(self):
+        return ISSUES[self.slug][1].format(**self.params)
+
+    @property
+    def long_description(self):
+        return ISSUES[self.slug][2].format(**self.params)
+
+    @property
+    def context(self):
+        if not self.content:
+            return ''
+
+        raw = self.content.raw
+        start_line = raw.count('\n', 0, self.start)
+        end_line = raw.count('\n', 0, self.end)
+        ctx_start_line = max(0, start_line - 2)
+        ctx_end_line = min(end_line + 3, raw.count('\n'))
+        digits = len(text_type(ctx_end_line))
+        context_lines = raw.split('\n')[ctx_start_line:ctx_end_line]
+
+        # Highlight the errored portion
+        err_page_bits = []
+        err_line_count = 1
+        for p, c in enumerate(raw):  # pragma: no branch
+            if c == '\n':
+                err_page_bits.append(c)
+                err_line_count += 1
+                if err_line_count > ctx_end_line:
+                    break
+            elif p < self.start or p >= self.end:
+                err_page_bits.append(' ')
+            else:
+                err_page_bits.append('^')
+        err_page = ''.join(err_page_bits)
+        err_lines = err_page.split('\n')[ctx_start_line:ctx_end_line]
+
+        out = []
+        for num, (line, err_line) in enumerate(zip(context_lines, err_lines)):
+            lnum = ctx_start_line + num
+            out.append(
+                text_type(lnum).rjust(digits) + ' ' + line)
+            if '^' in err_line:
+                out.append('*' * digits + ' ' + err_line)
+
+        return '\n'.join(out)
+
+    def get_severity_display(self):
+        return SEVERITIES[self.severity]
 
 
 @python_2_unicode_compatible

--- a/mdn/models.py
+++ b/mdn/models.py
@@ -289,7 +289,7 @@ ISSUES = {
         ' cell in the row, or a missing header cell.'),
     'failed_download': (
         CRITICAL, 'Failed to download {url}.',
-        'Status {status}, Content:\n{text}'),
+        'Status {status}, Content:\n{content}'),
     'false_start': (
         CRITICAL,
         'No <h2> found in page.',

--- a/mdn/models.py
+++ b/mdn/models.py
@@ -402,6 +402,11 @@ ISSUES = {
         ERROR,
         'KumaScript {kumascript} should have 1 non-blank argument',
         'Argument should be the MDN key that will return a maturity'),
+    'spec2_converted': (
+        WARNING,
+        'Specification status should be converted to KumaScript',
+        'Expected KumaScript {{{{Spec2("{key}")}}}}, but got text'
+        ' "{original}".'),
     'unexpected_attribute': (
         WARNING,
         'Unexpected attribute <{node_type} {ident}="{value}">',

--- a/mdn/models.py
+++ b/mdn/models.py
@@ -98,12 +98,15 @@ class FeaturePage(models.Model):
         """Get the page translations, after fetching the meta data."""
         meta = self.meta()
         translations = []
-        for locale, path in meta.locale_paths():
+        for locale, path, title in meta.locale_paths():
             content, created = self.translatedcontent_set.get_or_create(
                 locale=locale, defaults={
-                    'path': path,
-                    'raw': '',
+                    'path': path, 'raw': '', 'title': title,
                     'status': TranslatedContent.STATUS_STARTING})
+            if content.title != title or content.path != path:
+                content.path = path
+                content.title = title
+                content.save()
             translations.append(content)
         return translations
 
@@ -142,11 +145,14 @@ class FeaturePage(models.Model):
                 ('parent', str(self.feature.parent_id)),
                 ('children', []),
             )))))
+        canonical = (list(feature['name'].keys()) == ['zxx'])
+        if canonical:
+            feature['name'] = feature['name']['zxx']
         for t in self.translations():
             if t.locale != 'en-US':
                 feature['mdn_uri'][t.locale] = t.url()
-        if ['zxx'] == list(feature['name'].keys()):
-            feature['name'] = feature['name']['zxx']
+                if not canonical:
+                    feature['name'][t.locale] = t.title
 
         view_feature = OrderedDict((
             ('features', feature),
@@ -504,7 +510,7 @@ class Issue(models.Model):
 class Content(models.Model):
     """The content of an MDN page."""
     page = models.ForeignKey(FeaturePage)
-    path = models.CharField(help_text="Path of MDN page", max_length=255)
+    path = models.CharField(help_text="Path of MDN page", max_length=1024)
     crawled = ModificationDateTimeField(
         help_text="Time when the content was retrieved")
     raw = models.TextField(help_text="Raw content of the page")
@@ -548,9 +554,9 @@ class PageMeta(Content):
         if self.status != self.STATUS_FETCHED:
             return []
         meta = self.data()
-        locale_paths = [(meta['locale'], meta['url'])]
+        locale_paths = [(meta['locale'], meta['url'], meta['title'])]
         for t in meta['translations']:
-            locale_paths.append((t['locale'], t['url']))
+            locale_paths.append((t['locale'], t['url'], t['title']))
         return locale_paths
 
 
@@ -559,3 +565,4 @@ class TranslatedContent(Content):
     locale = models.CharField(
         help_text="Locale for page translation",
         max_length=5, db_index=True)
+    title = models.TextField(help_text="Page title in locale", blank=True)

--- a/mdn/models.py
+++ b/mdn/models.py
@@ -116,7 +116,6 @@ class FeaturePage(models.Model):
         drop_cache - Delete cached MDN content
         """
         self.status = FeaturePage.STATUS_STARTING
-        self.issues.all().delete()
         self.reset_data()
         self.save()
         meta = self.meta()
@@ -128,8 +127,12 @@ class FeaturePage(models.Model):
                 t.raw = ""
                 t.save()
 
-    def reset_data(self):
-        """Reset JSON data to initial state"""
+    def reset_data(self, keep_issues=False):
+        """Reset JSON data to initial state.
+
+        If keep_issues is False (default), issues are dropped. If true, then
+        issues are added to meta.scrape.issues.
+        """
         feature = OrderedDict((
             ('id', str(self.feature.id)),
             ('slug', self.feature.slug),
@@ -154,6 +157,18 @@ class FeaturePage(models.Model):
                 if not canonical:
                     feature['name'][t.locale] = t.title
 
+        issues = []
+        if keep_issues:
+            for issue in self.issues.order_by('id'):
+                issue_plus = [issue.slug, issue.start, issue.end, issue.params]
+                if issue.content:
+                    issue_plus.append(issue.content.locale)
+                else:
+                    issue_plus.append(None)
+                issues.append(issue_plus)
+        else:
+            self.issues.all().delete()
+
         view_feature = OrderedDict((
             ('features', feature),
             ('linked', OrderedDict((
@@ -175,7 +190,7 @@ class FeaturePage(models.Model):
                 ))),
                 ("scrape", OrderedDict((
                     ("phase", "Starting Import"),
-                    ("issues", []),
+                    ("issues", issues),
                     ("raw", None)))))))))
 
         self.data = view_feature
@@ -189,14 +204,7 @@ class FeaturePage(models.Model):
         except (ValueError, TypeError):
             data = {}
         if not data:
-            data = self.reset_data()
-
-        # Add issues
-        issues = []
-        for issue in self.issues.order_by('id'):
-            issues.append([
-                issue.slug, issue.start, issue.end, issue.params])
-        data['meta']['scrape']['issues'] = issues
+            data = self.reset_data(keep_issues=True)
 
         return data
 
@@ -207,14 +215,21 @@ class FeaturePage(models.Model):
 
     @property
     def has_issues(self):
-        return self.issues.exists()
+        return bool(sum(self.issue_counts.values()))
 
     @property
     def issue_counts(self):
         if not getattr(self, '_issue_counts', None):
             self._issue_counts = {WARNING: 0, ERROR: 0, CRITICAL: 0}
-            for issue in self.issues.all():
-                self._issue_counts[issue.severity] += 1
+            issues = self.data['meta']['scrape']['issues']
+            if not issues:
+                # Legacy - get from raw data
+                raw = self.data['meta']['scrape']['raw'] or {}
+                issues = raw.get('issues', [])
+            for issue in issues:
+                slug = issue[0]
+                severity = ISSUES[slug][0]
+                self._issue_counts[severity] += 1
         return self._issue_counts
 
     @property
@@ -240,8 +255,15 @@ class FeaturePage(models.Model):
         # Did we already add this issue?
         if self.issues.filter(slug=slug, start=start, end=end).exists():
             raise ValueError("Duplicate issue")
+
+        # Add issue to database, data
+        data = self.data
         self.issues.create(
             slug=slug, start=start, end=end, params=params, content=content)
+        issue_plus = list(issue)
+        issue_plus.append(locale)
+        data['meta']['scrape']['issues'].append(issue_plus)
+        self.data = data
         self._issue_counts = None
 
     @models.permalink

--- a/mdn/models.py
+++ b/mdn/models.py
@@ -373,6 +373,19 @@ ISSUES = {
         ' Spec2({spec2_key}).',
         'SpecName and Spec2 must refer to the same mdn_key. Update the MDN'
         ' page.'),
+    'specname_blank_key': (
+        ERROR,
+        'KumaScript SpecName has a blank key',
+        'Update the MDN page to include a valid mdn_key'),
+    'spec2_wrong_kumascript': (
+        ERROR,
+        'Expected KumaScript Spec2(), got {kumascript}',
+        'Change to Spec2(mdn_key), using the mdn_key from the SpecName()'
+        ' KumaScript.'),
+    'spec2_arg_count': (
+        ERROR,
+        'KumaScript {kumascript} should have 1 argument',
+        'Argument should be the MDN key that will return a maturity'),
     'unexpected_attribute': (
         WARNING,
         'Unexpected attribute <{node_type} {ident}="{value}">',
@@ -386,7 +399,7 @@ ISSUES = {
         ' be added to the API.'),
     'unknown_kumascript': (
         ERROR,
-        'Unknown KumaScript {display} in {scope}.',
+        'Unknown KumaScript {kumascript} in {scope}.',
         'The importer has to run custom code to import KumaScript, and it'
         ' hasn\'t been taught how to import {name} when it appears in a'
         ' {scope}. File a bug, or convert the MDN page to not use this'

--- a/mdn/models.py
+++ b/mdn/models.py
@@ -373,6 +373,16 @@ ISSUES = {
         ERROR,
         'Nested <p> tags are not supported.',
         'Edit the MDN page to remove the nested <p> tag'),
+    'missing_attribute': (
+        ERROR,
+        'The tag <{node_type}> is missing the expected attribute {ident}',
+        'Add the missing attribute or convert the tag to plain text.'),
+    'second_footnote': (
+        ERROR,
+        'An additional footnote was detected in content',
+        'The footnote [{original}] is being used, and the footnote [{new}]'
+        ' discarded.  If footnotes are in the same <p> and split by <br>'
+        ' tags, then split into paragraphs to fix.'),
     'section_skipped': (
         CRITICAL,
         'Section <h2>{title}</h2> has unexpected content.',
@@ -387,6 +397,12 @@ ISSUES = {
         'The import of section {title} failed, but no parse error was'
         ' detected. This is usually because of a previous critical error,'
         ' which must be cleared before any parsing can be attempted.'),
+    'skipped_h3': (
+        WARNING,
+        '<h3>{h3}</h3> was not imported.',
+        '<h3> subsections are usually prose compatibility information, and'
+        ' anything after an <h3> is not parsed or imported. Convert to'
+        ' footnotes or move to a different <h2> section.'),
     'spec_h2_id': (
         WARNING,
         'Expected <h2 id="Specifications">, actual id={h2_id}',
@@ -433,6 +449,12 @@ ISSUES = {
         ERROR,
         '{kumascript} is invalid in the spec description',
         'Handled as if {{{{SpecName(...)}}}} was used. Update the MDN page.'),
+    'tag_dropped': (
+        WARNING,
+        'HTML element {tag} (but not wrapped content) was removed.',
+        'The element {tag} is not allowed in the {scope} scope, and was'
+        ' removed. You can remove the tag from the MDN page to remove the'
+        ' warning.'),
     'unexpected_attribute': (
         WARNING,
         'Unexpected attribute <{node_type} {ident}="{value}">',

--- a/mdn/models.py
+++ b/mdn/models.py
@@ -361,11 +361,11 @@ ISSUES = {
         ' which must be cleared before any parsing can be attempted.'),
     'spec_h2_id': (
         WARNING,
-        'Expected <h2 id="Specifications">, actual id={{h2_id}}',
+        'Expected <h2 id="Specifications">, actual id={h2_id}',
         'Fix the id so that the table of contents, other feature work.'),
     'spec_h2_name': (
         WARNING,
-        'Expected <h2 name="Specifications">, actual name={{h2_name}}',
+        'Expected <h2 name="Specifications">, actual name={h2_name}',
         'Fix or remove the name attribute.'),
     'spec_mismatch': (
         ERROR,
@@ -384,7 +384,7 @@ ISSUES = {
         ' KumaScript.'),
     'spec2_arg_count': (
         ERROR,
-        'KumaScript {kumascript} should have 1 argument',
+        'KumaScript {kumascript} should have 1 non-blank argument',
         'Argument should be the MDN key that will return a maturity'),
     'unexpected_attribute': (
         WARNING,
@@ -408,7 +408,7 @@ ISSUES = {
         ERROR,
         'Unknown Specification "{key}".',
         'The API does not have a specification with mdn_key "{key}".'
-        ' This could be a typo on the MDN page, or the specfication needs to'
+        ' This could be a typo on the MDN page, or the specification needs to'
         ' be added to the API.'),
     'unknown_version': (
         ERROR,

--- a/mdn/models.py
+++ b/mdn/models.py
@@ -23,7 +23,7 @@ def validate_mdn_url(value):
     disallowed_chars = '?$#'
     for c in disallowed_chars:
         if c in value:
-            raise ValidationError('"?" is not allowed in URL')
+            raise ValidationError('"{}" is not allowed in URL'.format(c))
     allowed_prefix = False
     for allowed in settings.MDN_ALLOWED_URLS:
         allowed_prefix = allowed_prefix or value.startswith(allowed)

--- a/mdn/models.py
+++ b/mdn/models.py
@@ -275,6 +275,11 @@ ISSUES = {
         'Unknown Gecko version "{version}"',
         'The importer does not recognize this version for CompatGeckoFxOS.'
         ' Change the MDN page or update the importer.'),
+    'doc_parse_error': (
+        CRITICAL,
+        'No imported data due to unexpected page structure.',
+        'The importer was unable to handle the page structure enough to'
+        ' determine if there was compatibility data.'),
     'exception': (CRITICAL, 'Unhandled exception', '{traceback}'),
     'extra_cell': (
         ERROR,

--- a/mdn/models.py
+++ b/mdn/models.py
@@ -47,6 +47,7 @@ class FeaturePage(models.Model):
     STATUS_PARSING = 3
     STATUS_PARSED = 4
     STATUS_ERROR = 5
+    STATUS_NO_DATA = 6
     STATUS_CHOICES = (
         (STATUS_STARTING, "Starting Import"),
         (STATUS_META, "Fetching Metadata"),
@@ -54,6 +55,7 @@ class FeaturePage(models.Model):
         (STATUS_PARSING, "Parsing MDN pages"),
         (STATUS_PARSED, "Parsing Complete"),
         (STATUS_ERROR, "Scraping Failed"),
+        (STATUS_NO_DATA, "No Compat Data"),
     )
     status = models.IntegerField(
         help_text="Status of MDN Parsing process",

--- a/mdn/models.py
+++ b/mdn/models.py
@@ -429,6 +429,10 @@ ISSUES = {
         'Specification status should be converted to KumaScript',
         'Expected KumaScript {{{{Spec2("{key}")}}}}, but got text'
         ' "{original}".'),
+    'specdesc_spec2_invalid': (
+        ERROR,
+        '{kumascript} is invalid in the spec description',
+        'Handled as if {{{{SpecName(...)}}}} was used. Update the MDN page.'),
     'unexpected_attribute': (
         WARNING,
         'Unexpected attribute <{node_type} {ident}="{value}">',

--- a/mdn/models.py
+++ b/mdn/models.py
@@ -228,7 +228,7 @@ class FeaturePage(models.Model):
                 issues = raw.get('issues', [])
             for issue in issues:
                 slug = issue[0]
-                severity = ISSUES[slug][0]
+                severity = ISSUES.get(slug, UNKNOWN_ISSUE)[0]
                 self._issue_counts[severity] += 1
         return self._issue_counts
 
@@ -466,6 +466,9 @@ ISSUES = {
         ' be added to the API.'),
 }
 
+UNKNOWN_ISSUE = (
+    CRITICAL, 'Unknown Issue', "This issue slug doesn't have a description.")
+
 
 @python_2_unicode_compatible
 class Issue(models.Model):
@@ -494,15 +497,15 @@ class Issue(models.Model):
 
     @property
     def severity(self):
-        return ISSUES[self.slug][0]
+        return ISSUES.get(self.slug, UNKNOWN_ISSUE)[0]
 
     @property
     def brief_description(self):
-        return ISSUES[self.slug][1].format(**self.params)
+        return ISSUES.get(self.slug, UNKNOWN_ISSUE)[1].format(**self.params)
 
     @property
     def long_description(self):
-        return ISSUES[self.slug][2].format(**self.params)
+        return ISSUES.get(self.slug, UNKNOWN_ISSUE)[2].format(**self.params)
 
     @property
     def context(self):

--- a/mdn/models.py
+++ b/mdn/models.py
@@ -436,8 +436,8 @@ ISSUES = {
     'unexpected_attribute': (
         WARNING,
         'Unexpected attribute <{node_type} {ident}="{value}">',
-        'For <{node_type}>, the importer is ready for the attributes'
-        ' {expected}. This unexpected attribute will be discarded.'),
+        'For <{node_type}>, the importer expects {expected}. This unexpected'
+        ' attribute will be discarded.'),
     'unknown_browser': (
         ERROR,
         'Unknown Browser "{name}".',

--- a/mdn/scrape.py
+++ b/mdn/scrape.py
@@ -72,7 +72,10 @@ specname_td = td_open _ specname_text "</td>"
 specname_text = kumascript / inner_td
 spec2_td = td_open _ spec2_text "</td>"
 spec2_text = kumascript / inner_td
-specdesc_td = td_open _ inner_td _ "</td>"
+specdesc_td = td_open _ specdesc_text _ "</td>"
+specdesc_text = specdesc_token*
+specdesc_token = kumascript / code_block / spec_other
+spec_other = ~r"(?P<content>[^{<]+)\s*"s
 inner_td = ~r"(?P<content>.*?(?=</td>))"s
 
 #
@@ -105,8 +108,8 @@ compat_row_cell = td_open _ compat_cell _ "</td>" _
 #   Due to rowspan and colspan usage, we won't know if a cell is a feature
 #   or a support until we visit the table.
 #
-compat_cell = compat_cell_item*
-compat_cell_item = (kumascript / cell_break / code_block / cell_p_open /
+compat_cell = compat_cell_token*
+compat_cell_token = (kumascript / cell_break / code_block / cell_p_open /
     cell_p_close / cell_version / cell_footnote_id / cell_removed / cell_other)
 cell_break = "<" _ "br" _ ("/>" / ">") _
 code_block = "<code>" _ code_text _ "</code>" _
@@ -215,9 +218,15 @@ class PageVisitor(NodeVisitor):
         """Visitor when none is specified."""
         return visited_children or node
 
-    def _visit_content(self, node, args):
+    def _visit_content(self, node, children):
         """Vistor for re nodes with a named (?P<content>) section."""
         return node.match.group('content')
+
+    def _visit_token(self, node, children):
+        """Visitor for one of many tokenized items"""
+        token = children[0]
+        assert isinstance(token, dict), type(token)
+        return token
 
     def visit_doc(self, node, children):
         """At the top level, return all the collected data."""
@@ -406,10 +415,39 @@ class PageVisitor(NodeVisitor):
         return key
 
     def visit_specdesc_td(self, node, children):
-        item = children[2]
-        assert isinstance(item, dict), type(item)
-        assert item['type'] == 'text'
-        return item['content']
+        specdesc = children[2]
+        bits = []
+        if isinstance(specdesc, Node):
+            assert specdesc.start == specdesc.end
+        else:
+            assert isinstance(specdesc, list), type(specdesc)
+            for item in specdesc:
+                if item['type'] == 'kumascript':
+                    if item['name'] == 'xref_csslength':
+                        assert not item['args']
+                        bits.append("<code>&lt;length&gt;</code>")
+                    elif item['name'] == 'cssxref':
+                        assert len(item['args']) == 1
+                        bits.append("<code>{}</code>".format(item['args'][0]))
+                    else:
+                        self.issues.append(self.kumascript_issue(
+                            'unknown_kumascript', item, 'specdesc'))
+                elif item['type'] == 'code_block':
+                    bits.append("<code>{}</code>".format(item['content']))
+                else:
+                    assert item['type'] == 'text'
+                    bits.append(item['content'])
+
+        # Re-join the content
+        out = ""
+        nospace = '!,.;? '
+        for bit in bits:
+            if out and out[-1] not in nospace and bit[0] not in nospace:
+                out += " "
+            out += bit
+        return out
+
+    visit_specdesc_token = _visit_token
 
     def visit_inner_td(self, node, children):
         text = self.cleanup_whitespace(node.text)
@@ -417,6 +455,8 @@ class PageVisitor(NodeVisitor):
         return {
             'type': 'text', 'content': text,
             'start': node.start, 'end': node.end}
+
+    visit_spec_other = visit_inner_td
 
     #
     # Browser Compatibility section
@@ -643,11 +683,7 @@ class PageVisitor(NodeVisitor):
     # Browser Compatibility table cells
     #  Due to rowspan and colspan usage, we won't know if a cell is a feature
     #  or a support until visit_compat_body
-
-    def visit_compat_cell_item(self, node, children):
-        item = children[0]
-        assert isinstance(item, dict), type(item)
-        return item
+    visit_compat_cell_token = _visit_token
 
     def visit_cell_break(self, node, children):
         return {'type': 'break', 'start': node.start, 'end': node.end}

--- a/mdn/scrape.py
+++ b/mdn/scrape.py
@@ -27,7 +27,6 @@ from itertools import chain
 import re
 import string
 
-from django.utils.html import escape
 from django.utils.six import text_type
 from parsimonious import IncompleteParseError, ParseError
 from parsimonious.grammar import Grammar
@@ -187,8 +186,7 @@ class PageVisitor(NodeVisitor):
     - 'compat': Data scraped from the Browser Compatibility table
     - 'footnotes': Footnotes appearing after the Browser Compatibility table,
       but not referenced in the table
-    - 'issues': Ignorable issues with the parsed page
-    - 'errors': Problems that a human should deal with.
+    - 'issues': Issues with the parsed page
     """
     def __init__(self, feature, locale='en'):
         super(PageVisitor, self).__init__()
@@ -197,7 +195,6 @@ class PageVisitor(NodeVisitor):
         self.locale = locale
         self.specs = []
         self.issues = []
-        self.errors = []
         self.compat = []
         self.footnotes = None
         self._browser_data = None
@@ -217,7 +214,6 @@ class PageVisitor(NodeVisitor):
             'specs': self.specs,
             'locale': self.locale,
             'issues': self.issues,
-            'errors': self.errors,
             'compat': self.compat,
             'footnotes': self.footnotes,
         }
@@ -251,35 +247,18 @@ class PageVisitor(NodeVisitor):
                 try:
                     page_grammar[section].parse(text)
                 except ParseError as pe:
-                    if self.errors:
-                        rule = pe.expr
-                        description = (
-                            'Section <h2>%s</h2> was not parsed.'
-                            ' The parser failed on rule "%s", but the real'
-                            ' cause is probably earlier issues. Definition:'
-                            % (title, rule.name))
-                        self.errors.append((
-                            pe.pos + start,
-                            end_of_line(pe.text, pe.pos) + start,
-                            description, rule.as_rule()))
-                    else:
-                        rule = pe.expr
-                        description = (
-                            'Section <h2>%s</h2> was not parsed. The parser'
-                            ' failed on rule "%s", but the real cause may be'
-                            ' unexpected content after this position.'
-                            ' Definition:' % (title, rule.name))
-                        self.errors.append((
-                            pe.pos + start,
-                            end_of_line(pe.text, pe.pos) + start,
-                            description, rule.as_rule()))
-
+                    expr = pe.expr
+                    self.issues.append((
+                        'section_skipped',
+                        pe.pos + start, end_of_line(pe.text, pe.pos) + start,
+                        {'rule_name': expr.name, 'title': title,
+                         'rule': expr.as_rule()}))
                 else:
-                    error = (
-                        start, end_of_line(text, 0) + start,
-                        "Section %s not parsed, probably due to earlier"
-                        " errors." % title)
-                    self.errors.append(error)
+                    self.issues.append((
+                        'section_missed',
+                        start,
+                        end_of_line(text, 0) + start,
+                        {'title': title}))
 
     visit_last_section = visit_other_section
 
@@ -296,18 +275,15 @@ class PageVisitor(NodeVisitor):
             if attr['ident'] == 'id':
                 h2_id = attr['value']
                 if h2_id not in expected:
-                    issue = (
-                        'In Specifications section, expected <h2'
-                        ' id="Specifications">, actual id=' '"%s"' % h2_id)
-                    self.issues.append((attr['start'], attr['end'], issue))
+                    self.issues.append((
+                        'spec_h2_id', attr['start'], attr['end'],
+                        {'h2_id': h2_id}))
             elif attr['ident'] == 'name':
                 h2_name = attr['value']
                 if h2_name not in expected:
-                    issue = (
-                        'In Specifications section, expected <h2'
-                        ' name="Specifications"> or no name attribute,'
-                        ' actual name="%s"' % h2_name)
-                    self.issues.append((attr['start'], attr['end'], issue))
+                    self.issues.append((
+                        'spec_h2_name', attr['start'], attr['end'],
+                        {'h2_name': h2_name}))
 
     def visit_spec_row(self, node, children):
         specname = children[2]
@@ -317,10 +293,9 @@ class PageVisitor(NodeVisitor):
         spec2_key = children[4]
         assert isinstance(spec2_key, text_type), spec2_key
         if spec2_key != key:
-            self.errors.append((
-                node.start, node.end,
-                ('SpecName(%s, ...) does not match Spec2(%s)'
-                 % (spec2_key, key))))
+            self.issues.append((
+                'spec_mismatch', node.start, node.end,
+                {'spec2_key': spec2_key, 'specname_key': key}))
             spec2_key = key
 
         desc = children[6]
@@ -357,8 +332,8 @@ class PageVisitor(NodeVisitor):
             spec = Specification.objects.get(mdn_key=key)
         except Specification.DoesNotExist:
             spec_id = None
-            self.errors.append(
-                (node.start, node.end, 'Unknown Specification "%s"' % key))
+            self.issues.append((
+                'unknown_spec', node.start, node.end, {'key': key}))
         else:
             spec_id = spec.id
         return (key, spec_id, subpath, name)
@@ -400,9 +375,9 @@ class PageVisitor(NodeVisitor):
                     try:
                         text, start, end = footnotes[f_id]
                     except KeyError:
-                        self.errors.append(
-                            (f_start, f_end,
-                             'Footnote [%s] not found' % f_id))
+                        self.issues.append((
+                            'footnote_missing', f_start, f_end,
+                            {'footnote_id': f_id}))
                     else:
                         support['footnote'] = text
                         used_footnotes.add(f_id)
@@ -411,8 +386,8 @@ class PageVisitor(NodeVisitor):
             del footnotes[f_id]
 
         for f_id, (text, start, end) in footnotes.items():
-            self.errors.append(
-                (start, end, 'Footnote [%s] not used' % f_id))
+            self.issues.append((
+                'footnote_unused', start, end, {'footnote_id': f_id}))
 
         self.compat = compat_divs
         self.footnotes = footnotes
@@ -481,8 +456,8 @@ class PageVisitor(NodeVisitor):
                 try:
                     col = table[row].index(None)
                 except ValueError:
-                    error = "Extra cell in table"
-                    self.errors.append((td['start'], cell[-1]['end'], error))
+                    self.issues.append((
+                        'extra_cell', td['start'], cell[-1]['end'], {}))
                     continue
                 rowspan = int(td.get('rowspan', 1))
                 colspan = int(td.get('colspan', 1))
@@ -527,8 +502,9 @@ class PageVisitor(NodeVisitor):
         # Verify feature header
         fcontent = feature['content']
         if fcontent['text'] != 'Feature':
-            issue = 'Expected header "Feature"'
-            self.issues.append((fcontent['start'], fcontent['end'], issue))
+            self.issues.append((
+                'feature_header', fcontent['start'], fcontent['end'],
+                {'header': fcontent['text']}))
 
         # Process client headers
         expected_attrs = ('colspan',)
@@ -542,8 +518,9 @@ class PageVisitor(NodeVisitor):
             assert isinstance(name, text_type), type(name)
             b_id, b_name, b_slug = self.browser_id_name_and_slug(name)
             if is_fake_id(b_id):
-                issue = 'Unknown Browser "%s"' % name
-                self.errors.append((content['start'], content['end'], issue))
+                self.issues.append((
+                    'unknown_browser', content['start'], content['end'],
+                    {'name': name}))
             client = {
                 'name': b_name,
                 'id': b_id,
@@ -683,8 +660,8 @@ class PageVisitor(NodeVisitor):
                 if 'footnote_id' in item:
                     footnote.append(item)
                 else:
-                    self.errors.append((
-                        item['start'], item['end'], "No ID in footnote."))
+                    self.issues.append((
+                        'footnote_no_id', item['start'], item['end'], {}))
             elif item.get('footnote_id'):
                 # New footnote
                 add_footnote(footnote)
@@ -847,10 +824,12 @@ class PageVisitor(NodeVisitor):
                 assert ident not in node_out
                 node_out[ident] = attr['value']
             else:
+                expected_text = (
+                    ', '.join(expected[:-1]) + ' or ' + expected[-1])
                 self.issues.append((
-                    attr['start'], attr['end'],
-                    "Unexpected attribute <%s %s=\"%s\">" % (
-                        node_dict['type'], ident, attr['value'])))
+                    'unexpected_attribute', attr['start'], attr['end'],
+                    {'node_type': node_dict['type'], 'ident': ident,
+                        'value': attr['value'], 'expected': expected_text}))
         return node_out
 
     def visit_th_elem(self, node, children):
@@ -915,6 +894,17 @@ class PageVisitor(NodeVisitor):
                 raise ValueError(text)
             return text[1:-1]
         return text
+
+    def unknown_kumascript_issue(self, scope, item):
+        """Create an unknown_kumascript issue."""
+        if item['args']:
+            args = '(' + ', '.join(item['args']) + ')'
+        else:
+            args = ''
+        return (
+            'unknown_kumascript', item['start'], item['end'],
+            {'name': item['name'], 'args': item['args'], 'scope': scope,
+             'display': "{{%s%s}}" % (item['name'], args)})
 
     #
     # API lookup methods
@@ -1069,18 +1059,11 @@ class PageVisitor(NodeVisitor):
                 elif kname == 'domxref':
                     name_bits.append(self.unquote(item['args'][0]))
                 else:
-                    if item['args']:
-                        args = '(' + ', '.join(item['args']) + ')'
-                    else:
-                        args = ''
-                    error = (
-                        'Unknown kumascript function %s%s'
-                        % (item['name'], args))
-                    self.errors.append((item['start'], item['end'], error))
+                    self.issues.append(self.unknown_kumascript_issue(
+                        'compatibility feature', item))
             elif item['type'] == 'footnote_id':
-                self.errors.append((
-                    item['start'], item['end'],
-                    'Footnotes are not allowed on features'))
+                self.issues.append((
+                    'footnote_feature', item['start'], item['end'], {}))
             else:
                 raise ValueError("Unknown item!", item)
         assert name_bits
@@ -1140,9 +1123,10 @@ class PageVisitor(NodeVisitor):
                 version_found = item['version']
             elif item['type'] == 'footnote_id':
                 if 'footnote_id' in support:
-                    self.errors.append((
-                        item['start'], item['end'],
-                        'Only one footnote allowed.'))
+                    self.issues.append((
+                        'footnote_multiple', item['start'], item['end'],
+                        {'prev_footnote_id': support['footnote_id'][0],
+                         'footnote_id': item['footnote_id']}))
                 else:
                     support['footnote_id'] = (
                         item['footnote_id'], item['start'], item['end'])
@@ -1171,9 +1155,10 @@ class PageVisitor(NodeVisitor):
                             version_found = text_type(nversion)
                         else:
                             version_found = None
-                            self.errors.append((
+                            self.issues.append((
+                                'compatgeckodesktop_unknown',
                                 item['start'], item['end'],
-                                'Unknown Gecko version "%s"' % gversion))
+                                {'version': gversion}))
                 elif kname == 'compatgeckofxos':
                     gversion = self.unquote(item['args'][0])
                     try:
@@ -1212,14 +1197,14 @@ class PageVisitor(NodeVisitor):
                           oversion in ('', '2.2')):
                         version_found = '2.2'
                     elif nversion < 0 or nversion >= 38:
-                        self.errors.append((
-                            item['start'], item['end'],
-                            'Unknown Gecko version "%s"' % gversion))
+                        self.issues.append((
+                            'compatgeckofxos_unknown',
+                            item['start'], item['end'], {'version': gversion}))
                     else:
-                        self.errors.append((
+                        self.issues.append((
+                            'compatgeckofxos_override',
                             item['start'], item['end'],
-                            ('Override "%s" is invalid for '
-                             'Gecko version "%s"' % (oversion, gversion))))
+                            {'override': oversion, 'version': gversion}))
                 elif kname == 'compatgeckomobile':
                     gversion = self.unquote(item['args'][0])
                     version_found = gversion.split('.', 1)[0]
@@ -1228,20 +1213,13 @@ class PageVisitor(NodeVisitor):
                 elif kname in kumascript_compat_versions:
                     version_found = self.unquote(item['args'][0])
                 else:
-                    if item['args']:
-                        args = '(' + ', '.join(item['args']) + ')'
-                    else:
-                        args = ''
-                    error = (
-                        'Unknown kumascript function %s%s' %
-                        (item['name'], args))
-                    self.errors.append((item['start'], item['end'], error))
+                    self.issues.append(self.unknown_kumascript_issue(
+                        'compatibility cell', item))
             elif item['type'] == 'p_open':
                 p_depth += 1
                 if p_depth > 1:
-                    self.errors.append((
-                        item['start'], item['end'],
-                        'Nested <p> tags not supported'))
+                    self.issues.append((
+                        'nested_p', item['start'], item['end'], {}))
             elif item['type'] == 'p_close' and p_depth > 1:
                 # No support for nested <p> tags
                 p_depth -= 1
@@ -1266,16 +1244,13 @@ class PageVisitor(NodeVisitor):
                 support['support'] = 'no'
             elif item['type'] == 'text':
                 if item['content']:
-                    # Inline text requires human intervention to move to a
-                    #  footnote, convert to a normal version, or remove.
-                    self.errors.append((
-                        item['start'], item['end'],
-                        'Unknown support text "%s"' % item['content']))
+                    self.issues.append((
+                        'inline_text', item['start'], item['end'],
+                        {'text': item['content']}))
             elif item['type'] == 'code_block':
-                self.errors.append((
-                    item['start'], item['end'],
-                    'Unknown support text <code>%s</code>' %
-                    item['content']))
+                self.issues.append((
+                    'inline_text', item['start'], item['end'],
+                    {'text': '<code>{}</code>'.format(item['content'])}))
             else:
                 raise ValueError("Unknown item", item)
 
@@ -1286,12 +1261,12 @@ class PageVisitor(NodeVisitor):
                 new_version = is_fake_id(version_id)
                 new_browser = is_fake_id(browser['id'])
                 if new_version and not new_browser:
-                    self.errors.append((
-                        item['start'], item['end'],
-                        'Unknown version "%s" for browser "%s"'
-                        ' (id %d, slug "%s")' % (
-                            version_found, browser['name'], browser['id'],
-                            browser.get('slug', '<not loaded>'))))
+                    self.issues.append((
+                        'unknown_version', item['start'], item['end'],
+                        {'browser_id': browser['id'],
+                         'browser_name': browser['name'],
+                         'version': version_found,
+                         'browser_slug': browser.get('slug', '<not loaded>')}))
                 version['id'] = version_id
                 version['version'] = version_name
                 support_id = self.support_id(version_id, feature['id'])
@@ -1364,14 +1339,12 @@ class PageVisitor(NodeVisitor):
                 kumascript = "<code>%s</code>" % self.unquote(arglist[0])
             else:
                 kumascript = ""
-                if arglist:
-                    args = '(' + ', '.join(arglist) + ')'
-                else:
-                    args = ''
-                self.errors.append((
-                    start + match.start(), start + match.end(),
-                    "Unknown footnote kumascript function %s%s" %
-                    (name, args)))
+                item = {
+                    'name': name, 'args': arglist,
+                    'start': start + match.start(),
+                    'end': start + match.end()}
+                self.issues.append(self.unknown_kumascript_issue(
+                    'footnote', item))
             rendered = (
                 rendered[:match.start()] + kumascript + rendered[match.end():])
         return rendered
@@ -1384,39 +1357,22 @@ def scrape_page(mdn_page, feature, locale='en'):
         ('compat', []),
         ('footnotes', None),
         ('issues', []),
-        ('errors', []),
     ))
     if '<h2' not in mdn_page:
-        data['errors'].append('No <h2> found in page')
+        data['issues'].append(('false_start', 0, len(mdn_page), {}))
         return data
 
     try:
         page_parsed = page_grammar.parse(mdn_page)
     except IncompleteParseError as ipe:
-        error = (
-            ipe.pos, end_of_line(ipe.text, ipe.pos),
-            'Unable to finish parsing MDN page, starting at this position.')
-        data['errors'].append(error)
-        return data
-    except ParseError as pe:  # pragma: no cover
-        # TODO: Add a test once we know how to trigger
-        # Because the rules include optional sections, parse issues mostly
-        # appear as IncompleteParseError or skipping a section.  A small
-        # change to the rules may turn these into ParseErrors instead.
-        # PageVisitor.visit_other_section() handles skipped sections.
-        rule = pe.expr
-        error = (
-            pe.pos, end_of_line(pe.text, pe.pos),
-            'Rule "%s" failed to match.  Rule definition:' % rule.name,
-            rule.as_rule())
-        data['errors'].append(error)
+        data['issues'].append((
+            'halt_import', ipe.pos, end_of_line(ipe.text, ipe.pos), {}))
         return data
     page_data = PageVisitor(feature).visit(page_parsed)
 
     data['specs'] = page_data.get('specs', [])
     data['compat'] = page_data.get('compat', [])
     data['issues'] = page_data.get('issues', [])
-    data['errors'] = page_data.get('errors', [])
     data['footnotes'] = page_data.get('footnotes', None)
     return data
 
@@ -1791,12 +1747,8 @@ def scrape_feature_page(feature_page):
     feature_page.data = view_feature.generate_data()
 
     # Add issues
-    for err in chain(scraped_data['issues'], scraped_data['errors']):
-        if isinstance(err, tuple):
-            html = range_error_to_html(en_content.raw, *err)
-            feature_page.add_error(html, True)
-        else:
-            feature_page.add_error(err)
+    for issue in scraped_data['issues']:
+        feature_page.add_issue(issue, 'en-US')
 
     # Update status, issues
     feature_page.status = feature_page.STATUS_PARSED
@@ -1825,49 +1777,6 @@ def end_of_line(text, pos):
 def is_fake_id(_id):
     # Detect if an ID is a real ID
     return isinstance(_id, text_type) and _id[0] == '_'
-
-
-def range_error_to_html(page, start, end, reason, rule=None):
-    """Convert a range error to HTML"""
-    assert page, "Page can not be empty"
-    html_bits = ["<div><p>", escape(reason), "</p>"]
-    if rule:
-        html_bits.extend(("<p><code>", escape(rule), "</code></p>"))
-
-    # Get 2 lines of context around error
-    html_bits.append('<p>Context:<pre>')
-    start_line = page.count('\n', 0, start)
-    end_line = page.count('\n', 0, end)
-    ctx_start_line = max(0, start_line - 2)
-    ctx_end_line = min(end_line + 3, page.count('\n'))
-    digits = len(text_type(ctx_end_line))
-    context_lines = page.split('\n')[ctx_start_line:ctx_end_line]
-
-    # Highlight the errored portion
-    err_page_bits = []
-    err_line_count = 1
-    for p, c in enumerate(page):  # pragma: no branch
-        if c == '\n':
-            err_page_bits.append(c)
-            err_line_count += 1
-            if err_line_count > ctx_end_line:
-                break
-        elif p < start or p >= end:
-            err_page_bits.append(' ')
-        else:
-            err_page_bits.append('^')
-    err_page = ''.join(err_page_bits)
-    err_lines = err_page.split('\n')[ctx_start_line:ctx_end_line]
-
-    for num, (line, err_line) in enumerate(zip(context_lines, err_lines)):
-        lnum = ctx_start_line + num
-        html_bits.append(
-            text_type(lnum).rjust(digits) + ' ' + escape(line) + '\n')
-        if '^' in err_line:
-            html_bits.append('*' * digits + ' ' + err_line + '\n')
-
-    html_bits.append("</pre></p></div>")
-    return ''.join(html_bits)
 
 
 def slugify(word, length=50, suffix=""):

--- a/mdn/scrape.py
+++ b/mdn/scrape.py
@@ -1821,6 +1821,8 @@ def scrape_feature_page(feature_page):
     # Add issues
     for issue in scraped_data['issues']:
         feature_page.add_issue(issue, 'en-US')
+    merged_data['meta']['scrape']['issues'] = (
+        feature_page.data['meta']['scrape']['issues'])
 
     # Update status, issues
     has_data = (scraped_data['specs'] or scraped_data['compat'] or

--- a/mdn/scrape.py
+++ b/mdn/scrape.py
@@ -775,20 +775,8 @@ class PageVisitor(NodeVisitor):
                             bits.append(text)
                     else:
                         assert item_type == 'pre'
-                        allowed = {
-                            'class': ['brush:css'],
-                        }
-                        attrs = []
-                        for name, vitem in item['attributes'].items():
-                            assert name in allowed
-                            value = vitem['value']
-                            assert value in allowed[name]
-                            attrs.append((name, value))
-                        attrs.sort()
-                        attr_out = " ".join('%s="%s"' % a for a in attrs)
-                        attr_space = ' ' if attr_out else ''
-                        bits.append('<pre{}{}>{}</pre>'.format(
-                            attr_space, attr_out, item['content']))
+                        out = self._consume_attributes(item, [])
+                        bits.append('<pre>{}</pre>'.format(out['content']))
                 line = self.join_content(bits)
                 if line:
                     if include_p and wrap_p:
@@ -918,8 +906,14 @@ class PageVisitor(NodeVisitor):
                 assert ident not in node_out
                 node_out[ident] = attr['value']
             else:
-                expected_text = (
-                    ', '.join(expected[:-1]) + ' or ' + expected[-1])
+                if len(expected) > 1:
+                    expected_text = (
+                        'the attributes ' + ', '.join(expected[:-1]) + ' or ' +
+                        expected[-1])
+                elif len(expected) == 1:
+                    expected_text = 'the attribute ' + expected[0]
+                else:
+                    expected_text = 'no attributes'
                 self.issues.append((
                     'unexpected_attribute', attr['start'], attr['end'],
                     {'node_type': node_dict['type'], 'ident': ident,

--- a/mdn/scrape.py
+++ b/mdn/scrape.py
@@ -1644,6 +1644,8 @@ class ScrapedViewFeature(object):
                 ('supports', support_ids),
                 ('parent', parent_id),
                 ('children', children_ids))))))
+        if list(feature.name.keys()) == ['zxx']:
+            feature_content['name'] = feature.name['zxx']
         return feature_content
 
     def new_feature(self, feature_entry):

--- a/mdn/scrape.py
+++ b/mdn/scrape.py
@@ -615,7 +615,7 @@ class PageVisitor(NodeVisitor):
         if raw_id.isnumeric():
             footnote_id = raw_id
         else:
-            footnote_id = str(len(raw_id))
+            footnote_id = text_type(len(raw_id))
         return {
             'type': 'footnote_id',
             'footnote_id': footnote_id,
@@ -696,7 +696,7 @@ class PageVisitor(NodeVisitor):
         if raw_id.isnumeric():
             footnote_id = raw_id
         else:
-            footnote_id = str(len(raw_id))
+            footnote_id = text_type(len(raw_id))
         return footnote_id
 
     visit_footnote_p_text = _visit_content
@@ -1462,7 +1462,7 @@ class ScrapedViewFeature(object):
             else:
                 browser_content = self.load_browser(browser_entry['id'])
             self.add_resource('browsers', browser_content)
-            tab['browsers'].append(str(browser_content['id']))
+            tab['browsers'].append(text_type(browser_content['id']))
 
         # Load Features (first column)
         for feature_entry in table['features']:
@@ -1472,7 +1472,7 @@ class ScrapedViewFeature(object):
                 feature_content = self.load_feature(feature_entry['id'])
             self.add_resource_if_new('features', feature_content)
             self.compat_table_supports.setdefault(
-                str(feature_content['id']), OrderedDict())
+                text_type(feature_content['id']), OrderedDict())
 
         # Load Versions (explicit or implied in cells)
         for version_entry in table['versions']:

--- a/mdn/scrape.py
+++ b/mdn/scrape.py
@@ -1745,7 +1745,12 @@ def scrape_page(mdn_page, feature, locale='en'):
         ('footnotes', None),
         ('issues', []),
     ))
-    if not mdn_page.strip():
+
+    # Quick check for data in page
+    if not (
+            ('Browser compatibility</h' in mdn_page) or
+            ('Specifications</h' in mdn_page) or
+            ('CompatibilityTable' in mdn_page)):
         return data
 
     try:

--- a/mdn/scrape.py
+++ b/mdn/scrape.py
@@ -1367,6 +1367,15 @@ def scrape_page(mdn_page, feature, locale='en'):
         data['issues'].append((
             'halt_import', ipe.pos, end_of_line(ipe.text, ipe.pos), {}))
         return data
+    except ParseError as pe:
+        if pe.expr.name == 'doc':
+            data['issues'].append((
+                'doc_parse_error', pe.pos, end_of_line(pe.text, pe.pos), {}))
+            return data
+        else:  # pragma: no cover
+            # Raise as 'exception' issue to flag for future work
+            raise pe
+
     page_data = PageVisitor(feature).visit(page_parsed)
 
     data['specs'] = page_data.get('specs', [])

--- a/mdn/scrape.py
+++ b/mdn/scrape.py
@@ -422,7 +422,7 @@ class PageVisitor(NodeVisitor):
             assert isinstance(specdesc, list), type(specdesc)
             for item in specdesc:
                 if item['type'] == 'kumascript':
-                    text = self.kumascript_to_text(item, 'specdesc')
+                    text = self.kumascript_to_html(item, 'specdesc')
                     if text:
                         bits.append(text)
                 elif item['type'] == 'code':
@@ -764,7 +764,7 @@ class PageVisitor(NodeVisitor):
                     elif item_type == 'text':
                         bits.append(item['content'])
                     elif item_type == 'kumascript':
-                        text = self.kumascript_to_text(item, 'footnote')
+                        text = self.kumascript_to_html(item, 'footnote')
                         if text:
                             bits.append(text)
                     else:
@@ -1014,8 +1014,8 @@ class PageVisitor(NodeVisitor):
             {'name': item['name'], 'args': item['args'], 'scope': scope,
              'kumascript': "{{%s%s}}" % (item['name'], args)})
 
-    def kumascript_to_text(self, item, scope):
-        """Convert kumascript to plain text."""
+    def kumascript_to_html(self, item, scope):
+        """Convert kumascript to plain HTML."""
         assert item['type'] == 'kumascript'
         name = item['name']
         args = item['args']

--- a/mdn/scrape.py
+++ b/mdn/scrape.py
@@ -907,9 +907,10 @@ class PageVisitor(NodeVisitor):
     def unquote(self, text):
         """Unquote strings."""
         if text.startswith('"') or text.startswith("'"):
-            if text[0] != text[-1]:
+            if text[0] == text[-1]:
+                return text[1:-1]
+            elif (text.count(text[0]) % 2) != 0:
                 raise ValueError(text)
-            return text[1:-1]
         return text
 
     def kumascript_issue(self, issue, item, scope):

--- a/mdn/scrape.py
+++ b/mdn/scrape.py
@@ -364,13 +364,13 @@ class PageVisitor(NodeVisitor):
             except Specification.DoesNotExist:
                 spec_id = None
                 self.issues.append((
-                    'unknown_spec', node.start, node.end, {'key': key}))
+                    'unknown_spec', item['start'], item['end'], {'key': key}))
             else:
                 spec_id = spec.id
         else:
             if item['type'] == 'kumascript':
                 self.issues.append((
-                    'specname_blank_key', node.start, node.end, {}))
+                    'specname_blank_key', item['start'], item['end'], {}))
             spec_id = None
 
         return (key, spec_id, subpath, name)

--- a/mdn/tasks.py
+++ b/mdn/tasks.py
@@ -50,7 +50,7 @@ def fetch_meta(featurepage_id):
 
     # Request and validate the metadata
     url = meta.url()
-    r = requests.get(url)
+    r = requests.get(url, headers={'Cache-Control': 'no-cache'})
     next_task = None
     next_task_args = []
     if r.status_code != requests.codes.ok:
@@ -140,7 +140,7 @@ def fetch_translation(featurepage_id, locale):
 
     # Request the translation
     url = t.url() + '?raw'
-    r = requests.get(t.url() + "?raw")
+    r = requests.get(t.url() + "?raw", headers={'Cache-Control': 'no-cache'})
     t.raw = r.text
     next_task = None
     next_task_args = []

--- a/mdn/templates/mdn/feature_page_detail.jinja2
+++ b/mdn/templates/mdn/feature_page_detail.jinja2
@@ -162,7 +162,7 @@ function load_tables(resources, lang) {
         mdn_uri = "https://developer.mozilla.org/";
     }
     $("#mdn_link").attr("href", mdn_uri);
-    $("#mdn_link").text(mdn_uri);
+    $("#mdn_link").text(decodeURIComponent(mdn_uri));
     $("#mdn_link_spec").attr("href", mdn_uri + "#Specifications")
     $("#mdn_link_compat").attr("href", mdn_uri + "#Browser_compatibility")
 

--- a/mdn/templates/mdn/feature_page_detail.jinja2
+++ b/mdn/templates/mdn/feature_page_detail.jinja2
@@ -54,7 +54,7 @@
 <form action="{{url('feature_page_reset', pk=object.pk)}}" method="post">
 {{ csrf() }}
 <input id="submit-reset" class="btn btn-primary" type="submit" value="Reset">
-<label for="submit-reset">Download MDN pages and reparse</label>
+<label for="submit-reset">Download MDN page and reparse</label>
 </form>
 <br/>
 {% endif %}
@@ -62,7 +62,7 @@
 <form id="form-reparse" action="{{url('feature_page_reparse', pk=object.pk)}}" method="post">
 {{ csrf() }}
 <input id="submit-reparse" class="btn btn-primary" type="submit" value="Reparse">
-<label for="submit-reparse">Re-parse the cached MDN pages</label>
+<label for="submit-reparse">Re-parse the cached MDN page</label>
 </form>
 <br/>
 {% endif %}

--- a/mdn/templates/mdn/feature_page_detail.jinja2
+++ b/mdn/templates/mdn/feature_page_detail.jinja2
@@ -26,13 +26,24 @@
     <dd>{{ object.same_since() }}</dd>
   <dt>Issues</dt>
     <dd>{% if object.has_issues %}
-      <ul>
-        {% for error in object.data['meta']['scrape']['errors'] %}
-        <li>{{ error | safe }}</li>
-        {% else %}
-        <li><em><code>.has_errors</code> is set, but no errors recorded</em></li>
+      <ol>
+        {% for issue in object.issues.order_by("start") %}
+        <li><div>
+            <p>
+                <strong>{{issue.get_severity_display()}}: {{issue.brief_description}}</strong><br/>
+                {{issue.long_description}}<br>
+                <a href="https://wiki.mozilla.org/MDN/Development/CompatibilityTables/Importer#{{issue.slug}}">More information about issue "{{issue.slug}}"</a>
+            </p>
+            {% if issue.params.get('rule') %}
+            <p><em>Parser rule:</em></p>
+            <p><code>{{ issue.params['rule'] }}</code></p>
+            {% endif %}
+            {% if issue.content %}
+            <p><em>Context:</em><pre>{{ issue.context }}</pre></p>
+            {% endif %}
+        </div></li>
         {% endfor %}
-      </ul>{% else %}
+      </ol>{% else %}
       <em>None detected</em>
       {% endif %}
     </dd>

--- a/mdn/templates/mdn/feature_page_detail.jinja2
+++ b/mdn/templates/mdn/feature_page_detail.jinja2
@@ -66,9 +66,9 @@
 </form>
 <br/>
 {% endif %}
-{% if can_commit_mdn_import(request.user) %}
-<form id="form-commit" class="hide"
- action="{{url('viewfeatures-detail', pk=object.feature_id)}}" method="put">
+{% if can_commit_mdn_import(request.user) and object.errors == 0 and object.critical == 0 %}
+<form id="form-commit" method="put"
+ action="{{url('viewfeatures-detail', pk=object.feature_id)}}">
 {{ csrf() }}
 <input id="submit-commit" class="btn btn-primary" type="submit" value="Commit">
 <label for="submit-commit">Commit data to the API</label>
@@ -219,9 +219,7 @@ function load_json(data) {
     $("#wpc_data").html(json_dump);
     window.resources = resources = WPC.parse_resources(data);
     load_tables(window.resources, "en");
-    if (data.meta.scrape.errors.length === 0) {
-        $("#form-commit").removeClass('hide').on('submit', commit_json);
-    }
+    $("#form-commit").on('submit', commit_json);
 };
 
 data = {{ object.raw_data | default('null', True) | safe }};

--- a/mdn/templates/mdn/feature_page_detail.jinja2
+++ b/mdn/templates/mdn/feature_page_detail.jinja2
@@ -109,7 +109,7 @@
   <a href="{{url('feature_page_json', pk=object.pk)}}">raw JSON-API data</a>
   resembles that returned from
   <code>
-    <a id="wpc_uri" href="/api/v1/view_features/{{feature_id}}">
+    <a id="wpc_uri" href="/api/v1/view_features/{{object.feature.id}}">
       /api/v1/view_features/{{object.feature.id}}
     </a>
   </code>

--- a/mdn/templates/mdn/feature_page_detail.jinja2
+++ b/mdn/templates/mdn/feature_page_detail.jinja2
@@ -81,7 +81,7 @@
 {% endif %}
 </div>
 
-{% if object.status == object.STATUS_PARSED %}
+{% if object.status in (object.STATUS_PARSED, object.STATUS_NO_DATA) %}
 <h1>Sample Presentation of {{object.slug()}}</h1>
 <h2>Specifications</h2>
 <div id="wpc_specifications">

--- a/mdn/templates/mdn/feature_page_detail.jinja2
+++ b/mdn/templates/mdn/feature_page_detail.jinja2
@@ -1,4 +1,5 @@
 {% extends "webplatformcompat/base.jinja2" %}
+{% import "mdn/macros.jinja2" as macros %}
 
 {% block head_title %}Parse results for {{object.slug()}}{% endblock %}
 {% block body_title %}Parse results for {{object.slug()}}{% endblock %}
@@ -27,22 +28,9 @@
   <dt>Issues</dt>
     <dd>{% if object.has_issues %}
       <ol>
-        {% for issue in object.issues.order_by("start") %}
-        <li><div>
-            <p>
-                <strong>{{issue.get_severity_display()}}: {{issue.brief_description}}</strong><br/>
-                {{issue.long_description}}<br>
-                <a href="https://wiki.mozilla.org/MDN/Development/CompatibilityTables/Importer#{{issue.slug}}">More information about issue "{{issue.slug}}"</a>
-            </p>
-            {% if issue.params.get('rule') %}
-            <p><em>Parser rule:</em></p>
-            <p><code>{{ issue.params['rule'] }}</code></p>
-            {% endif %}
-            {% if issue.content %}
-            <p><em>Context:</em><pre>{{ issue.context }}</pre></p>
-            {% endif %}
-        </div></li>
-        {% endfor %}
+        {% for issue in object.issues.order_by("start") -%}
+        <li>{{ macros.issue_div(issue) }}</li>
+        {% endfor -%}
       </ol>{% else %}
       <em>None detected</em>
       {% endif %}

--- a/mdn/templates/mdn/feature_page_list.jinja2
+++ b/mdn/templates/mdn/feature_page_list.jinja2
@@ -45,8 +45,10 @@
           {% else %}
             No Issues
           {% endif %}
+        {%- elif page.status == page.STATUS_NO_DATA %}
+          No Data
         {%- elif page.status == page.STATUS_ERROR %}
-          Scraping Failed
+          <strong>Scraping Failed</strong>
         {%- else %}
           <em>Still Processing</em>
         {%- endif -%}

--- a/mdn/templates/mdn/feature_page_list.jinja2
+++ b/mdn/templates/mdn/feature_page_list.jinja2
@@ -4,7 +4,9 @@
 {% block body_title %}MDN Importer{% endblock %}
 
 {% block quick_nav %}
-<p><em>back to <a href="{{ url('home') }}">home</a></em></p>
+<p><em>go back to <a href="{{ url('home') }}">home</a>, or
+  see a <a href="{{ url('issues_summary') }}">summary of current issues</a>.
+</em></p>
 {% endblock %}
 
 {% block content %}

--- a/mdn/templates/mdn/feature_page_list.jinja2
+++ b/mdn/templates/mdn/feature_page_list.jinja2
@@ -16,25 +16,54 @@
     <input type="url" class="form-control" id="id-url" name="url"
      placeholder="https://developer.mozilla.org/en-US/docs/...">
   </div>
-  <input id="fp-search" class="btn btn-primary" type="submit" value="Search by URL">
+  <input id="fp-search" class="btn btn-primary" type="submit"
+   value="Search or Filter by URL">
 </form>
+
+<h3>Filter by Topic </h3>
+<div>
+{% for topic_name in topics %}
+{% if topic == topic_name %}
+<a class="btn btn-primary"
+   href="{{url('feature_page_list')}}">
+  {{topic_name}} (clear)
+</a>
+{% else %}
+<a class="btn btn-default"
+   href="{{url('feature_page_list') + '?topic=' + topic_name}}">
+  {{topic_name}}
+</a>
+{% endif %}
+{% endfor %}
+{% if topic and topic not in topics %}
+<a class="btn btn-primary">{{topic}} (clear)</a>
+{% endif %}
+</div>
+
 {% if page_obj %}
+<h3>
+    Import Results
+    ({{page_obj.paginator.count}}
+    import{% if page_obj.paginator.count > 1 %}s{% endif %})
+</h3>
 {{ pagination_control(page_obj, url('feature_page_list')) }}
 <table class="table table-condensed">
   <thead>
     <tr>
-      <th>#</th>
-      <th>Feature ID</th>
       <th>MDN Slug</th>
       <th>Status</th>
-      <th>Warnings /<br/>Errors /<br/>Critical Errors</th>
+      <th>
+        <span id="issue-header"
+              data-toggle="tooltip" data-placement="top"
+              title="Warnings / Errors / Critical Errors">
+          Issues
+        </span>
+      </th>
     </tr>
   </thead>
   <tbody>
     {% for page in page_obj.object_list %}
     <tr>
-      <td><a href="{{ url('feature_page_detail', pk=page.id) }}">{{page.id}}</a></td>
-      <td>{{page.feature_id}}</td>
       <td>{{page.slug()}}</td>
       <td><a href="{{ url('feature_page_detail', pk=page.id) }}">{{page.get_status_display()}}</a></td>
       <td>
@@ -68,3 +97,11 @@
 {% endif %}
 
 {% endblock content %}
+
+{% block block_js_extra %}
+<script>
+$(function () {
+  $('#issue-header').tooltip()
+})
+</script>
+{% endblock %}

--- a/mdn/templates/mdn/feature_page_list.jinja2
+++ b/mdn/templates/mdn/feature_page_list.jinja2
@@ -25,7 +25,7 @@
       <th>Feature ID</th>
       <th>MDN Slug</th>
       <th>Status</th>
-      <th>Has Issues?</th>
+      <th>Warnings /<br/>Errors /<br/>Critical Errors</th>
     </tr>
   </thead>
   <tbody>
@@ -38,12 +38,17 @@
       <td>
         <a href="{{ url('feature_page_detail', pk=page.id) }}">
         {%- if page.status == page.STATUS_PARSED -%}
-          {%- if page.has_issues %}<strong>Yes</strong>{% else %}No{%endif -%}
+          {%- if page.has_issues %}
+            {{page.warnings}} / {{page.errors}} / {{ page.critical }}
+          {% else %}
+            No Issues
+          {% endif %}
         {%- elif page.status == page.STATUS_ERROR %}
           Scraping Failed
         {%- else %}
           <em>Still Processing</em>
         {%- endif -%}
+        </a>
       </td>
     </tr>
     {% endfor %}

--- a/mdn/templates/mdn/issues_detail.jinja2
+++ b/mdn/templates/mdn/issues_detail.jinja2
@@ -1,0 +1,46 @@
+{% extends "webplatformcompat/base.jinja2" %}
+{% import "mdn/macros.jinja2" as macros %}
+
+{% macro title() -%}
+    MDN Importer issue <code>{{slug}}</code>
+    {% if count %}
+    {% endif %}
+{%- endmacro %}
+
+{% block head_title %}{{title()}}{% endblock %}
+{% block body_title %}{{title()}}{% endblock %}
+
+{% block quick_nav %}
+<p><em>back to
+    <a href="{{ url('issues_summary') }}">issues summary</a>, or the
+    <a href="{{ url('feature_page_list') }}">list of imported pages</a></em></p>
+{% endblock %}
+
+{% block content %}
+{% if count %}
+<p>
+    There are
+    {{count}} count{% if count != 1%}s{% endif %} of this issue
+    on {{pages | length}} page{% if pages | length > 1 %}s{% endif %}.
+<p>
+<h3>Sample</h3>
+<p>
+    Here's a sample from the import of
+    <a href="{{url('feature_page_detail', pk=sample_issue.page_id)}}">
+      {{sample_issue.page.slug()}}</a>:
+</p>
+<p>{{ macros.issue_div(sample_issue) }}</p>
+<h3>Imports with this issue</h3>
+<p>Here's the full list of imports where this issue was found:<p>
+<ul>
+{% for key, page_count in pages | dictsort -%}
+<li>
+    {{page_count}} in
+    <a href="{{url('feature_page_detail', pk=key[1])}}">{{key[0]}}</a>
+</li>
+{%- endfor %}
+</ul>
+{% else %}
+<p>There are no pages with this issue.</p>
+{% endif %}
+{% endblock content %}

--- a/mdn/templates/mdn/issues_summary.jinja2
+++ b/mdn/templates/mdn/issues_summary.jinja2
@@ -1,0 +1,28 @@
+{% extends "webplatformcompat/base.jinja2" %}
+
+{% block head_title %}MDN Importer - {{ total_issues}} Issue{% if total_issues != 1%}s{% endif %}{% endblock %}
+{% block body_title %}MDN Importer - {{ total_issues}} Issue{% if total_issues != 1%}s{% endif %}{% endblock %}
+
+{% block quick_nav %}
+<p><em>back to <a href="{{ url('feature_page_list') }}">list of imported pages</a></em></p>
+{% endblock %}
+
+{% block content %}
+{% if issues %}
+<ul>
+{% for count, slug, severity, brief, examples in issues %}
+  {% if count > 0 %}
+  <li>{{count}} count{% if count > 1 %}s{% endif %} of <code>{{slug}}</code> ({{severity}}): {{brief}}  Examples:
+    <ul>
+      {% for pk, mdn_url in examples %}
+      <li><a href="{{ url('feature_page_detail', pk=pk) }}">{{mdn_url}}</a></li>
+      {% endfor %}
+    </ul>
+  </li>
+  {% endif %}
+{% endfor %}
+</ul>
+{% else %}
+<p><i>No issues found.</i></p>
+{% endif %}
+{% endblock content %}

--- a/mdn/templates/mdn/issues_summary.jinja2
+++ b/mdn/templates/mdn/issues_summary.jinja2
@@ -12,7 +12,9 @@
 <ul>
 {% for count, slug, severity, brief, examples in issues %}
   {% if count > 0 %}
-  <li>{{count}} count{% if count > 1 %}s{% endif %} of <code>{{slug}}</code> ({{severity}}): {{brief}}  Examples:
+  <li>{{count}} count{% if count > 1 %}s{% endif %} of
+      <a href="https://wiki.mozilla.org/MDN/Development/CompatibilityTables/Importer#{{slug}}"><code>{{slug}}</code></a>
+      ({{severity}}): {{brief}}  Example{% if count != 0 %}s{% endif %}:
     <ul>
       {% for pk, mdn_url in examples %}
       <li><a href="{{ url('feature_page_detail', pk=pk) }}">{{mdn_url}}</a></li>

--- a/mdn/templates/mdn/issues_summary.jinja2
+++ b/mdn/templates/mdn/issues_summary.jinja2
@@ -12,12 +12,17 @@
 <ul>
 {% for count, slug, severity, brief, examples in issues %}
   {% if count > 0 %}
-  <li>{{count}} count{% if count > 1 %}s{% endif %} of
-      <a href="https://wiki.mozilla.org/MDN/Development/CompatibilityTables/Importer#{{slug}}"><code>{{slug}}</code></a>
-      ({{severity}}): {{brief}}  Example{% if count != 0 %}s{% endif %}:
+  <li>
+    <a href="{{url('issues_detail', slug=slug)}}">
+      {{count}} count{% if count > 1 %}s{% endif %}</a>
+    of
+    <a href="https://wiki.mozilla.org/MDN/Development/CompatibilityTables/Importer#{{slug}}">
+      <code>{{slug}}</code></a>
+    ({{severity}})
+    Example{% if count != 0 %}s{% endif %}:
     <ul>
-      {% for pk, mdn_url in examples %}
-      <li><a href="{{ url('feature_page_detail', pk=pk) }}">{{mdn_url}}</a></li>
+      {% for mdn_path, pk in examples %}
+      <li><a href="{{ url('feature_page_detail', pk=pk) }}">{{mdn_path}}</a></li>
       {% endfor %}
     </ul>
   </li>

--- a/mdn/templates/mdn/macros.jinja2
+++ b/mdn/templates/mdn/macros.jinja2
@@ -1,0 +1,20 @@
+{% macro issue_div(issue) -%}
+<div>
+  <p>
+    <strong>{{issue.get_severity_display()}}: {{issue.brief_description}}</strong>
+    <br>
+    {{issue.long_description}}
+    <br>
+    <a href="https://wiki.mozilla.org/MDN/Development/CompatibilityTables/Importer#{{issue.slug}}">
+      More information about issue "{{issue.slug}}"
+    </a>
+  </p>
+{% if issue.params.get('rule') %}
+  <p><em>Parser rule:</em></p>
+  <p><code>{{ issue.params['rule'] }}</code></p>
+{% endif %}
+{% if issue.content %}
+  <p><em>Context:</em><pre>{{ issue.context }}</pre></p>
+{% endif %}
+</div>
+{%- endmacro %}

--- a/mdn/tests/test_models.py
+++ b/mdn/tests/test_models.py
@@ -233,15 +233,26 @@ Enjoy.
         self.issue.start = content.find('ERROR')
         self.issue.end = self.issue.start + len('ERROR')
         expected = """\
-0 Here's the error:
-1 ---> ERROR <-----
+1 Here's the error:
+2 ---> ERROR <-----
 *      ^^^^^       \n\
-2 Enjoy."""
+3 Enjoy."""
         self.assertEqual(expected, self.issue.context)
 
     def test_context_without_content(self):
         self.issue.content = None
         self.assertEqual("", self.issue.context)
+
+    def test_context_end_of_page(self):
+        content = "Line1\nLine2"
+        self.en_content.raw = content
+        self.issue.start = content.find('Line2')
+        self.issue.end = self.issue.start + len('Line')
+        expected = """\
+1 Line1
+2 Line2
+* ^^^^ """
+        self.assertEqual(expected, self.issue.context)
 
 
 class TestPageMetaModel(TestCase):

--- a/mdn/tests/test_models.py
+++ b/mdn/tests/test_models.py
@@ -112,6 +112,11 @@ class TestFeaturePageModel(TestCase):
         t_de = TranslatedContent.objects.get(page=self.fp, locale='de')
         self.assertEqual(t_de.status, PageMeta.STATUS_STARTING)
 
+    def test_get_data_canonical(self):
+        self.fp.feature.name = {'zxx': 'canonical'}
+        data = self.fp.data
+        self.assertEqual('canonical', data['features']['name'])
+
     def test_get_data_existing(self):
         self.fp.raw_data = '{"meta": {"scrape": {"issues": "x"}}}'
         expected = {"meta": {"scrape": {"issues": []}}}

--- a/mdn/tests/test_models.py
+++ b/mdn/tests/test_models.py
@@ -46,9 +46,11 @@ class TestFeaturePageModel(TestCase):
         self.metadata = {
             "locale": "en-US",
             "url": "https://developer.mozilla.org/en-US/docs/Web/CSS/float",
+            "title": "<float>",
             "translations": [{
                 "locale": "de",
                 "url": "https://developer.mozilla.org/de/docs/Web/CSS/float",
+                "title": "<float>",
             }],
         }
 
@@ -86,10 +88,10 @@ class TestFeaturePageModel(TestCase):
             page=self.fp, path='/foo/path', status=PageMeta.STATUS_FETCHED,
             raw=dumps(self.metadata))
         TranslatedContent.objects.create(
-            page=self.fp, locale='en', path='/foo/en/path',
+            page=self.fp, locale='en', path='/foo/en/path', title='title',
             status=PageMeta.STATUS_FETCHED, raw="Black, White, Yellow, Red")
         TranslatedContent.objects.create(
-            page=self.fp, locale='de', path='/foo/de/path',
+            page=self.fp, locale='de', path='/foo/de/path', title='title',
             status=PageMeta.STATUS_ERROR, raw="Schwarz, Weiß, Gelb, Rot")
 
     def test_reset(self):
@@ -259,17 +261,22 @@ class TestPageMetaModel(TestCase):
         data = {
             'locale': 'en-US',
             'url': 'https://developer.mozilla.org/en-US/docs/Web/CSS/display',
+            'title': 'display',
             'translations': [{
                 'locale': 'es',
                 'url': 'https://developer.mozilla.org/es/docs/Web/CSS/display',
+                'title': 'display',
             }],
         }
         self.meta.status = self.meta.STATUS_FETCHED
         self.meta.raw = dumps(data)
         expected = [
             ('en-US',
-             'https://developer.mozilla.org/en-US/docs/Web/CSS/display'),
-            ('es', 'https://developer.mozilla.org/es/docs/Web/CSS/display'),
+             'https://developer.mozilla.org/en-US/docs/Web/CSS/display',
+             'display'),
+            ('es',
+             'https://developer.mozilla.org/es/docs/Web/CSS/display',
+             'display'),
         ]
         self.assertEqual(expected, self.meta.locale_paths())
 
@@ -281,8 +288,7 @@ class TestTranslatedContentModel(TestCase):
             feature_id=666,
             status=FeaturePage.STATUS_PARSED)
         self.c = TranslatedContent(
-            page=fp,
-            locale="de",
+            page=fp, locale="de", title='<float>',
             path="/de/docs/Web/CSS/float")
 
     def test_str(self):

--- a/mdn/tests/test_scrape.py
+++ b/mdn/tests/test_scrape.py
@@ -1507,6 +1507,11 @@ class TestPageVisitor(ScrapeTestCase):
     def test_unquote_unbalanced(self):
         self.assertRaises(ValueError, self.visitor.unquote, "'Mixed\"")
 
+    def test_unquote_quote_plus_text(self):
+        # https://developer.mozilla.org/en-US/docs/Web/CSS/@viewport/max-zoom
+        text = '"max-zoom" descriptor'
+        self.assertEqual(text, self.visitor.unquote(text))
+
     def assert_browser_lookup(self, name, browser_id, fixed_name, slug):
         lookup = self.visitor.browser_id_name_and_slug(name)
         self.assertEqual(browser_id, lookup[0])

--- a/mdn/tests/test_scrape.py
+++ b/mdn/tests/test_scrape.py
@@ -314,12 +314,23 @@ class ScrapeTestCase(TestCase):
 </ul>""" % sample_spec_section
     _instance_specs = {
         (Maturity, 'CR'): {'name': '{"en": "Candidate Recommendation"}'},
+        (Maturity, 'WD'): {'name': '{"en": "Working Draft"}'},
         (Specification, 'css3_backgrounds'): {
             '_req': {'maturity': (Maturity, 'CR')},
             'mdn_key': 'CSS3 Backgrounds',
             'name': (
                 '{"en": "CSS Backgrounds and Borders Module Level&nbsp;3"}'),
             'uri': '{"en": "http://dev.w3.org/csswg/css3-background/"}'},
+        (Specification, 'css3_ui'): {
+            '_req': {'maturity': (Maturity, 'WD')},
+            'mdn_key': 'CSS3 UI',
+            'name': '{"en": "CSS Basic User Interface Module Level&nbsp;3"}',
+            'uri': '{"en": "http://dev.w3.org/csswg/css3-ui/"}'},
+        (Specification, 'web_audio_api'): {
+            '_req': {'maturity': (Maturity, 'WD')},
+            'mdn_key': 'Web Audio API',
+            'name': '{"en": "Web Audio API"}',
+            'uri': '{"en": "http://webaudio.github.io/web-audio-api/"}'},
         (Section, 'background-size'): {
             '_req': {'specification': (Specification, 'css3_backgrounds')},
             'subpath': '{"en": "#the-background-size"}'},
@@ -449,6 +460,7 @@ class TestPageVisitor(ScrapeTestCase):
         self.assertEqual(issues, self.visitor.issues)
 
     def test_spec_row_mismatch(self):
+        spec = self.get_instance(Specification, 'css3_ui')
         spec_row = '''\
 <tr>
   <td>{{ SpecName('CSS3 UI', '#cursor', 'cursor') }}</td>
@@ -464,9 +476,8 @@ class TestPageVisitor(ScrapeTestCase):
             'section.name': 'cursor',
             'specification.mdn_key': 'CSS3 UI',
             'section.id': None,
-            'specification.id': None}]
+            'specification.id': spec.id}]
         issues = [
-            ('unknown_spec', 7, 62, {'key': 'CSS3 UI'}),
             ('spec_mismatch', 0, 199,
              {'spec2_key': 'CSS3 Basic UI', 'specname_key': 'CSS3 UI'})]
         self.assert_spec_row(spec_row, expected_specs, issues)
@@ -498,6 +509,7 @@ class TestPageVisitor(ScrapeTestCase):
 
     def test_spec_row_no_thead(self):
         # https://developer.mozilla.org/en-US/docs/Web/API/AudioContext
+        spec = self.get_instance(Specification, 'web_audio_api')
         spec_row = '''\
 <tr>
   <td>{{SpecName('Web Audio API', '#the-audiocontext-interface',\
@@ -511,9 +523,8 @@ class TestPageVisitor(ScrapeTestCase):
             'section.name': 'AudioContext',
             'specification.mdn_key': 'Web Audio API',
             'section.id': None,
-            'specification.id': None}]
-        issues = [('unknown_spec', 7, 92, {'key': 'Web Audio API'})]
-        self.assert_spec_row(spec_row, expected_specs, issues)
+            'specification.id': spec.id}]
+        self.assert_spec_row(spec_row, expected_specs, [])
 
     def test_spec_row_known_spec(self):
         spec = self.get_instance(Specification, 'css3_backgrounds')
@@ -1640,17 +1651,17 @@ class TestScrape(ScrapeTestCase):
 
     def test_spec_only(self):
         """Test with a only a Specification section."""
+        spec = self.get_instance(Specification, 'css3_backgrounds')
         page = self.sample_spec_section
         specs = [{
             'specification.mdn_key': 'CSS3 Backgrounds',
-            'specification.id': None,
+            'specification.id': spec.id,
             'section.subpath': '#the-background-size',
             'section.name': 'background-size',
             'section.note': '',
             'section.id': None,
         }]
-        issues = [('unknown_spec', 251, 335, {'key': 'CSS3 Backgrounds'})]
-        self.assertScrape(page, specs, issues)
+        self.assertScrape(page, specs, [])
 
 
 class FeaturePageTestCase(ScrapeTestCase):

--- a/mdn/tests/test_scrape.py
+++ b/mdn/tests/test_scrape.py
@@ -504,7 +504,7 @@ class TestPageVisitor(ScrapeTestCase):
             'specification.mdn_key': 'HTML WHATWG',
             'section.id': None,
             'specification.id': None}]
-        issues = [('unknown_spec', 7, 179, {'key': 'HTML WHATWG'})]
+        issues = [('unknown_spec', 11, 174, {'key': 'HTML WHATWG'})]
         self.assert_spec_row(spec_row, expected_specs, issues)
 
     def test_spec_row_no_thead(self):
@@ -569,14 +569,14 @@ class TestPageVisitor(ScrapeTestCase):
         # https://developer.mozilla.org/en-US/docs/Web/API/DeviceMotionEvent
         specname_td = '<td>{{SpecName("Device Orientation")}}</td>'
         expected = ("Device Orientation", None, '', '')
-        issues = [('unknown_spec', 0, 43, {'key': 'Device Orientation'})]
+        issues = [('unknown_spec', 4, 38, {'key': 'Device Orientation'})]
         self.assert_specname_td(specname_td, expected, issues)
 
     def test_specname_td_empty_key(self):
         # https://developer.mozilla.org/en-US/docs/Web/API/MIDIConnectionEvent
         specname_td = "<td>{{SpecName('', '#midiconnection')}}</td>"
         expected = ('', None, '#midiconnection', '')
-        issues = [('specname_blank_key', 0, 44, {})]
+        issues = [('specname_blank_key', 4, 39, {})]
         self.assert_specname_td(specname_td, expected, issues)
 
     def test_specname_td_ES1_legacy(self):
@@ -586,7 +586,7 @@ class TestPageVisitor(ScrapeTestCase):
         issues = [
             ('specname_converted', 4, 27,
              {'original': 'ECMAScript 1st Edition.', 'key': 'ES1'}),
-            ('unknown_spec', 0, 32, {'key': 'ES1'})]
+            ('unknown_spec', 4, 27, {'key': 'ES1'})]
         self.assert_specname_td(specname_td, expected, issues)
 
     def test_specname_td_ES3_legacy(self):
@@ -596,7 +596,7 @@ class TestPageVisitor(ScrapeTestCase):
         issues = [
             ('specname_converted', 5, 29,
              {'original': 'ECMAScript 3rd Edition.', 'key': 'ES3'}),
-            ('unknown_spec', 0, 34, {'key': 'ES3'})]
+            ('unknown_spec', 5, 29, {'key': 'ES3'})]
         self.assert_specname_td(specname_td, expected, issues)
 
     def test_specname_td_other(self):

--- a/mdn/tests/test_scrape.py
+++ b/mdn/tests/test_scrape.py
@@ -1544,6 +1544,10 @@ class TestScrape(ScrapeTestCase):
         page = "<h2>Incomplete</h2><p>Incomplete</p>"
         self.assertScrape(page, [], [('halt_import', 0, 36, {})])
 
+    def test_not_compat_page(self):
+        page = "<h3>I'm not a compat page</h3>"
+        self.assertScrape(page, [], [('doc_parse_error', 0, 30, {})])
+
     def test_spec_only(self):
         """Test with a only a Specification section."""
         page = self.sample_spec_section

--- a/mdn/tests/test_scrape.py
+++ b/mdn/tests/test_scrape.py
@@ -1618,11 +1618,11 @@ class FeaturePageTestCase(ScrapeTestCase):
             url=url, feature=self.feature, status=FeaturePage.STATUS_PARSING)
         meta = self.page.meta()
         meta.raw = dumps({
-            'locale': 'en-US',
-            'url': path,
+            'locale': 'en-US', 'url': path, 'title': 'background-size',
             'translations': [{
                 'locale': 'fr',
-                'url': path.replace('en-US', 'fr')
+                'url': path.replace('en-US', 'fr'),
+                'title': 'background-size',
             }]})
         meta.status = meta.STATUS_FETCHED
         meta.save()

--- a/mdn/tests/test_scrape.py
+++ b/mdn/tests/test_scrape.py
@@ -971,8 +971,8 @@ class TestPageVisitor(ScrapeTestCase):
         row_cell = '<td><code>canonical</code></td>'
         expected_cell = [
             {'type': 'td', 'start': 0, 'end': 4},
-            {'type': 'code_block', 'content': 'canonical', 'start': 4,
-             'end': 26},
+            {'type': 'code', 'content': 'canonical', 'attributes': {},
+             'start': 4, 'end': 26},
         ]
         self.assert_compat_row_cell(row_cell, expected_cell, [])
 
@@ -1586,7 +1586,7 @@ class TestPageVisitor(ScrapeTestCase):
                 ".foo {background-image: url(bg-image.png);}\n</pre>",
                 0, 103)}
         issues = [
-            ('unexpected_attribute', 33, 51,
+            ('unexpected_attribute', 34, 51,
              {'ident': 'class', 'node_type': 'pre', 'value': 'brush:css',
               'expected': 'no attributes'})]
         self.assert_compat_footnotes(footnotes, expected, issues)

--- a/mdn/tests/test_scrape.py
+++ b/mdn/tests/test_scrape.py
@@ -1583,6 +1583,31 @@ class TestPageVisitor(ScrapeTestCase):
         issues = [('footnote_no_id', 0, 18, {})]
         self.assert_compat_footnotes(footnotes, {}, issues)
 
+    def test_compat_footnotes_empty_paragraph_no_footnotes(self):
+        footnotes = ('<p>  </p>\n')
+        self.assert_compat_footnotes(footnotes, {}, [])
+
+    def test_compat_footnotes_empty_paragraph_invalid_footnote(self):
+        footnotes = (
+            '<p> </p>\n'
+            '<p>Invalid footnote.</p>\n'
+            '<p>  </p>')
+        issues = [('footnote_no_id', 9, 34, {})]
+        self.assert_compat_footnotes(footnotes, {}, issues)
+        self.assertEqual(footnotes[9:34], '<p>Invalid footnote.</p>\n')
+
+    def test_compat_footnotes_empty_paragraphs_trimmed(self):
+        footnote = (
+            '<p> </p>\n'
+            '<p>[1] Valid footnote.</p>'
+            '<p>   </p>'
+            '<p>Continues footnote 1.</p>')
+        expected = {
+            '1': (
+                '<p>Valid footnote.</p>\n<p>Continues footnote 1.</p>',
+                9, 73)}
+        self.assert_compat_footnotes(footnote, expected, [])
+
     def assert_kumascript(self, text, name, args, issues=None):
         parsed = page_grammar['kumascript'].parse(text)
         expected = {

--- a/mdn/tests/test_scrape.py
+++ b/mdn/tests/test_scrape.py
@@ -1731,86 +1731,86 @@ class TestPageVisitor(ScrapeTestCase):
         text = '"max-zoom" descriptor'
         self.assertEqual(text, self.visitor.unquote(text))
 
-    def assert_kumascript_to_text(
+    def assert_kumascript_to_html(
             self, kumascript, expected_text, scope='specdesc', issues=None):
         parsed = page_grammar['kumascript'].parse('{{' + kumascript + '}}')
         item = self.visitor.visit(parsed)
-        text = self.visitor.kumascript_to_text(item, scope)
+        text = self.visitor.kumascript_to_html(item, scope)
         self.assertEqual(expected_text, text)
         self.assertEqual(self.visitor.issues, issues or [])
 
-    def test_kumascript_to_text_xref_csslength(self):
+    def test_kumascript_to_html_xref_csslength(self):
         # https://developer.mozilla.org/en-US/docs/Web/CSS/vertical-align
-        self.assert_kumascript_to_text(
+        self.assert_kumascript_to_html(
             'xref_csslength()', '<code>&lt;length&gt;</code>')
 
-    def test_kumascript_to_text_xref_csspercentage(self):
+    def test_kumascript_to_html_xref_csspercentage(self):
         # https://developer.mozilla.org/en-US/docs/Web/CSS/position_value
-        self.assert_kumascript_to_text(
+        self.assert_kumascript_to_html(
             'xref_csspercentage()', '<code>&lt;percentage&gt;</code>')
 
-    def test_kumascript_to_text_xref_cssstring(self):
+    def test_kumascript_to_html_xref_cssstring(self):
         # https://developer.mozilla.org/en-US/docs/Web/CSS/attr
-        self.assert_kumascript_to_text(
+        self.assert_kumascript_to_html(
             'xref_cssstring()', '<code>&lt;string&gt;</code>')
 
-    def test_kumascript_to_text_xref_cssimage(self):
+    def test_kumascript_to_html_xref_cssimage(self):
         # https://developer.mozilla.org/en-US/docs/Web/CSS/list-style-image
-        self.assert_kumascript_to_text(
+        self.assert_kumascript_to_html(
             'xref_cssimage()', '<code>&lt;image&gt;</code>')
 
-    def test_kumascript_to_text_xref_csscolorvalue(self):
+    def test_kumascript_to_html_xref_csscolorvalue(self):
         # https://developer.mozilla.org/en-US/docs/Web/CSS/background-color
-        self.assert_kumascript_to_text(
+        self.assert_kumascript_to_html(
             'xref_csscolorvalue()', '<code>&lt;color&gt;</code>')
 
-    def test_kumascript_to_text_xref_cssvisual(self):
+    def test_kumascript_to_html_xref_cssvisual(self):
         # https://developer.mozilla.org/en-US/docs/Web/CSS/break-after
-        self.assert_kumascript_to_text('xref_cssvisual', '<code>visual</code>')
+        self.assert_kumascript_to_html('xref_cssvisual', '<code>visual</code>')
 
-    def test_kumascript_to_text_cssxref(self):
+    def test_kumascript_to_html_cssxref(self):
         # https://developer.mozilla.org/en-US/docs/Web/CSS/vertical-align
-        self.assert_kumascript_to_text(
+        self.assert_kumascript_to_html(
             'cssxref("display")', '<code>display</code>')
 
-    def test_kumascript_to_text_domxref_1arg(self):
+    def test_kumascript_to_html_domxref_1arg(self):
         # https://developer.mozilla.org/en-US/docs/Web/API/CharacterData
-        self.assert_kumascript_to_text(
+        self.assert_kumascript_to_html(
             'domxref("ChildNode")', '<code>ChildNode</code>')
 
-    def test_kumascript_to_text_domxref_2arg(self):
+    def test_kumascript_to_html_domxref_2arg(self):
         # https://developer.mozilla.org/en-US/docs/Web/API/CustomEvent/initCustomEvent
-        self.assert_kumascript_to_text(
+        self.assert_kumascript_to_html(
             'domxref("CustomEvent.CustomEvent", "CustomEvent()")',
             '<code>CustomEvent()</code>')
 
-    def test_kumascript_to_text_htmlelement(self):
+    def test_kumascript_to_html_htmlelement(self):
         # https://developer.mozilla.org/en-US/docs/Web/API/HTMLIsIndexElement
-        self.assert_kumascript_to_text(
+        self.assert_kumascript_to_html(
             'HTMLElement("isindex")', '<code>isindex</code>')
 
-    def test_kumascript_to_text_jsxref_1arg(self):
+    def test_kumascript_to_html_jsxref_1arg(self):
         # https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array
-        self.assert_kumascript_to_text(
+        self.assert_kumascript_to_html(
             'jsxref("Array.isArray")', '<code>Array.isArray</code>')
 
-    def test_kumascript_to_text_jsxref_2arg(self):
+    def test_kumascript_to_html_jsxref_2arg(self):
         # https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/toString
-        self.assert_kumascript_to_text(
+        self.assert_kumascript_to_html(
             'jsxref("Global_Objects/null", "null")', '<code>null</code>')
 
-    def test_kumascript_to_text_specname(self):
+    def test_kumascript_to_html_specname(self):
         # https://developer.mozilla.org/en-US/docs/Web/API/AbstractWorker
-        self.assert_kumascript_to_text(
+        self.assert_kumascript_to_html(
             'SpecName("Web Workers")', 'specification Web Workers')
 
-    def test_kumascript_to_text_unknown_kumascript(self):
+    def test_kumascript_to_html_unknown_kumascript(self):
         issues = [
             ('unknown_kumascript', 0, 23,
              {'name': 'Unknown', 'args': ['textarea'],
               'scope': 'specdesc',
               'kumascript': '{{Unknown(textarea)}}'})]
-        self.assert_kumascript_to_text(
+        self.assert_kumascript_to_html(
             'Unknown("textarea")', None, issues=issues)
 
     def assert_join_content(self, content_bits, expected_text):

--- a/mdn/tests/test_scrape.py
+++ b/mdn/tests/test_scrape.py
@@ -1626,6 +1626,16 @@ class TestPageVisitor(ScrapeTestCase):
                 9, 73)}
         self.assert_compat_footnotes(footnote, expected, [])
 
+    def test_compat_footnotes_code(self):
+        footnote = (
+            '<p>[1] From Firefox 31 to 35, <code>will-change</code>'
+            ' was available...</p>')
+        expected = {
+            '1': (
+                'From Firefox 31 to 35, <code>will-change</code>'
+                ' was available...', 0, 75)}
+        self.assert_compat_footnotes(footnote, expected, [])
+
     def assert_kumascript(self, text, name, args, issues=None):
         parsed = page_grammar['kumascript'].parse(text)
         expected = {

--- a/mdn/tests/test_scrape.py
+++ b/mdn/tests/test_scrape.py
@@ -1538,7 +1538,7 @@ class TestScrape(ScrapeTestCase):
 
     def test_empty(self):
         page = ""
-        self.assertScrape(page, [], [('false_start', 0, 0, {})])
+        self.assertScrape(page, [], [])
 
     def test_incomplete_parse_error(self):
         page = "<h2>Incomplete</h2><p>Incomplete</p>"
@@ -2013,14 +2013,13 @@ class TestScrapeFeaturePage(FeaturePageTestCase):
             translation.save()
 
     def test_empty_page(self):
-        self.set_content('')
+        self.set_content('  ')
         scrape_feature_page(self.page)
         fp = FeaturePage.objects.get(id=self.page.id)
-        self.assertEqual(fp.STATUS_PARSED, fp.status)
+        self.assertEqual(fp.STATUS_NO_DATA, fp.status)
         self.assertEqual(
-            [['false_start', 0, 0, {}]],
-            fp.data['meta']['scrape']['raw']['issues'])
-        self.assertTrue(fp.has_issues)
+            [], fp.data['meta']['scrape']['raw']['issues'])
+        self.assertFalse(fp.has_issues)
 
     def test_parse_issue(self):
         bad_page = '''\

--- a/mdn/tests/test_scrape.py
+++ b/mdn/tests/test_scrape.py
@@ -932,7 +932,7 @@ class TestPageVisitor(ScrapeTestCase):
              'expected': 'rowspan or colspan'})]
         self.assert_compat_row_cell(row_cell, expected_cell, issues)
 
-    def test_compat_row_cell_break(self):
+    def test_compat_row_break(self):
         row_cell = '<td>Multi-line<br/>feature</td>'
         expected_cell = [
             {'type': 'td', 'start': 0, 'end': 4},
@@ -953,7 +953,7 @@ class TestPageVisitor(ScrapeTestCase):
         ]
         self.assert_compat_row_cell(row_cell, expected_cell, [])
 
-    def test_compat_row_cell_code_block(self):
+    def test_compat_row_code_block(self):
         row_cell = '<td><code>canonical</code></td>'
         expected_cell = [
             {'type': 'td', 'start': 0, 'end': 4},

--- a/mdn/tests/test_scrape.py
+++ b/mdn/tests/test_scrape.py
@@ -1753,6 +1753,21 @@ class TestScrapedViewFeature(FeaturePageTestCase):
                 'sections': [], 'supports': []}}
         self.assertDataEqual(expected, feature_content)
 
+    def test_load_feature_canonical_name(self):
+        feature = self.create(
+            Feature, slug='web-css-background-size_list-item',
+            name={'zxx': 'list-item'}, parent=self.feature)
+        view = ScrapedViewFeature(self.page, self.empty_scrape())
+        feature_content = view.load_feature(feature.id)
+        expected = {
+            'id': str(feature.id), 'name': 'list-item',
+            'slug': feature.slug, 'mdn_uri': None, 'obsolete': False,
+            'stable': True, 'standardized': True, 'experimental': False,
+            'links': {
+                'children': [], 'parent': str(self.feature.id),
+                'sections': [], 'supports': []}}
+        self.assertDataEqual(expected, feature_content)
+
     def test_new_feature(self):
         feature_entry = {
             'id': '_feature', 'name': 'Basic support',

--- a/mdn/tests/test_scrape.py
+++ b/mdn/tests/test_scrape.py
@@ -1538,20 +1538,20 @@ class TestPageVisitor(ScrapeTestCase):
     def test_compat_footnotes_unknown_kumascriptscript(self):
         footnotes = (
             "<p>[1] Footnote {{UnknownKuma}} but the beat continues.</p>")
-        expected = {'1': ('Footnote  but the beat continues.', 0, 59)}
+        expected = {'1': ('Footnote but the beat continues.', 0, 59)}
         issues = [(
-            'unknown_kumascript', 15, 30,
+            'unknown_kumascript', 16, 32,
             {'name': 'UnknownKuma', 'args': [], 'scope': 'footnote',
              'kumascript': '{{UnknownKuma}}'})]
         self.assert_compat_footnotes(footnotes, expected, issues)
 
     def test_compat_footnotes_unknown_kumascriptscript_with_args(self):
         footnotes = '<p>[1] Footnote {{UnknownKuma("arg")}}</p>'
-        expected = {'1': ('Footnote ', 0, 42)}
+        expected = {'1': ('Footnote', 0, 42)}
         issues = [(
-            'unknown_kumascript', 15, 37,
-            {'name': 'UnknownKuma', 'args': ['"arg"'], 'scope': 'footnote',
-             'kumascript': '{{UnknownKuma("arg")}}'})]
+            'unknown_kumascript', 16, 38,
+            {'name': 'UnknownKuma', 'args': ['arg'], 'scope': 'footnote',
+             'kumascript': '{{UnknownKuma(arg)}}'})]
         self.assert_compat_footnotes(footnotes, expected, issues)
 
     def test_compat_footnotes_pre_section(self):

--- a/mdn/tests/test_scrape.py
+++ b/mdn/tests/test_scrape.py
@@ -1597,7 +1597,7 @@ class FeaturePageTestCase(ScrapeTestCase):
                            'Web/CSS/background-size'),
                     'fr': ('https://developer.mozilla.org/fr/docs/'
                            'Web/CSS/background-size')},
-                'name': {'zxx': 'background-size'},
+                'name': 'background-size',
                 'obsolete': False,
                 'slug': 'web-css-background-size',
                 'stable': True,

--- a/mdn/tests/test_scrape.py
+++ b/mdn/tests/test_scrape.py
@@ -717,14 +717,35 @@ class TestPageVisitor(ScrapeTestCase):
             ' <code>table-cell</code>.')
         self.assert_specdec_td(specdesc_td, expected, [])
 
-    def test_specdesc_td_unknown_kumascript(self):
-        specdesc_td = '<td>Baseline of {{HTMLElement("textarea")}}</td>'
-        expected = 'Baseline of'
+    def test_specdesc_td_kumascript_spec2(self):
+        # https://developer.mozilla.org/en-US/docs/Web/HTML/Element/data
+        specdesc_td = "<td>No change from {{Spec2('HTML5 W3C')}}</td>"
+        expected = "No change from specification HTML5 W3C"
         issues = [
-            ('unknown_kumascript', 16, 43,
-             {'name': 'HTMLElement', 'args': ['textarea'],
-              'scope': 'specdesc',
-              'kumascript': '{{HTMLElement(textarea)}}'})]
+            ('specdesc_spec2_invalid', 19, 41,
+             {'name': 'Spec2', 'args': ['HTML5 W3C'], 'scope': 'specdesc',
+              'kumascript': '{{Spec2(HTML5 W3C)}}'})]
+        self.assert_specdec_td(specdesc_td, expected, issues)
+
+    def test_specdesc_td_kumascript_experimental_inline(self):
+        # https://developer.mozilla.org/en-US/docs/Web/CSS/position_value
+        specdesc_td = (
+            '<td>Defines <code>&lt;position&gt;</code> explicitly and extends'
+            ' it to support offsets from any edge. {{ experimental_inline() }}'
+            '</td>')
+        expected = (
+            'Defines <code>&lt;position&gt;</code> explicitly and extends'
+            ' it to support offsets from any edge.')
+        self.assert_specdec_td(specdesc_td, expected, [])
+
+    def test_specdesc_td_spec2(self):
+        # https://developer.mozilla.org/en-US/docs/Web/HTML/Element/data
+        specdesc_td = "<td>No change from {{Spec2('HTML5 W3C')}}</td>"
+        expected = "No change from specification HTML5 W3C"
+        issues = [
+            ('specdesc_spec2_invalid', 19, 41,
+             {'name': 'Spec2', 'args': ['HTML5 W3C'], 'scope': 'specdesc',
+              'kumascript': '{{Spec2(HTML5 W3C)}}'})]
         self.assert_specdec_td(specdesc_td, expected, issues)
 
     def assert_compat_section(self, compat_section, compat, footnotes, issues):
@@ -1656,6 +1677,97 @@ class TestPageVisitor(ScrapeTestCase):
         # https://developer.mozilla.org/en-US/docs/Web/CSS/@viewport/max-zoom
         text = '"max-zoom" descriptor'
         self.assertEqual(text, self.visitor.unquote(text))
+
+    def assert_kumascript_to_text(
+            self, kumascript, expected_text, scope='specdesc', issues=None):
+        parsed = page_grammar['kumascript'].parse('{{' + kumascript + '}}')
+        item = self.visitor.visit(parsed)
+        text = self.visitor.kumascript_to_text(item, scope)
+        self.assertEqual(expected_text, text)
+        self.assertEqual(self.visitor.issues, issues or [])
+
+    def test_kumascript_to_text_xref_csslength(self):
+        # https://developer.mozilla.org/en-US/docs/Web/CSS/vertical-align
+        self.assert_kumascript_to_text(
+            'xref_csslength()', '<code>&lt;length&gt;</code>')
+
+    def test_kumascript_to_text_xref_csspercentage(self):
+        # https://developer.mozilla.org/en-US/docs/Web/CSS/position_value
+        self.assert_kumascript_to_text(
+            'xref_csspercentage()', '<code>&lt;percentage&gt;</code>')
+
+    def test_kumascript_to_text_xref_cssstring(self):
+        # https://developer.mozilla.org/en-US/docs/Web/CSS/attr
+        self.assert_kumascript_to_text(
+            'xref_cssstring()', '<code>&lt;string&gt;</code>')
+
+    def test_kumascript_to_text_xref_cssimage(self):
+        # https://developer.mozilla.org/en-US/docs/Web/CSS/list-style-image
+        self.assert_kumascript_to_text(
+            'xref_cssimage()', '<code>&lt;image&gt;</code>')
+
+    def test_kumascript_to_text_xref_csscolorvalue(self):
+        # https://developer.mozilla.org/en-US/docs/Web/CSS/background-color
+        self.assert_kumascript_to_text(
+            'xref_csscolorvalue()', '<code>&lt;color&gt;</code>')
+
+    def test_kumascript_to_text_xref_cssvisual(self):
+        # https://developer.mozilla.org/en-US/docs/Web/CSS/break-after
+        self.assert_kumascript_to_text('xref_cssvisual', '<code>visual</code>')
+
+    def test_kumascript_to_text_cssxref(self):
+        # https://developer.mozilla.org/en-US/docs/Web/CSS/vertical-align
+        self.assert_kumascript_to_text(
+            'cssxref("display")', '<code>display</code>')
+
+    def test_kumascript_to_text_domxref_1arg(self):
+        # https://developer.mozilla.org/en-US/docs/Web/API/CharacterData
+        self.assert_kumascript_to_text(
+            'domxref("ChildNode")', '<code>ChildNode</code>')
+
+    def test_kumascript_to_text_domxref_2arg(self):
+        # https://developer.mozilla.org/en-US/docs/Web/API/CustomEvent/initCustomEvent
+        self.assert_kumascript_to_text(
+            'domxref("CustomEvent.CustomEvent", "CustomEvent()")',
+            '<code>CustomEvent()</code>')
+
+    def test_kumascript_to_text_htmlelement(self):
+        # https://developer.mozilla.org/en-US/docs/Web/API/HTMLIsIndexElement
+        self.assert_kumascript_to_text(
+            'HTMLElement("isindex")', '<code>isindex</code>')
+
+    def test_kumascript_to_text_jsxref_1arg(self):
+        # https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array
+        self.assert_kumascript_to_text(
+            'jsxref("Array.isArray")', '<code>Array.isArray</code>')
+
+    def test_kumascript_to_text_jsxref_2arg(self):
+        # https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/toString
+        self.assert_kumascript_to_text(
+            'jsxref("Global_Objects/null", "null")', '<code>null</code>')
+
+    def test_kumascript_to_text_specname(self):
+        # https://developer.mozilla.org/en-US/docs/Web/API/AbstractWorker
+        self.assert_kumascript_to_text(
+            'SpecName("Web Workers")', 'specification Web Workers')
+
+    def test_kumascript_to_text_unknown_kumascript(self):
+        issues = [
+            ('unknown_kumascript', 0, 23,
+             {'name': 'Unknown', 'args': ['textarea'],
+              'scope': 'specdesc',
+              'kumascript': '{{Unknown(textarea)}}'})]
+        self.assert_kumascript_to_text(
+            'Unknown("textarea")', None, issues=issues)
+
+    def assert_join_content(self, content_bits, expected_text):
+        text = self.visitor.join_content(content_bits)
+        self.assertEqual(expected_text, text)
+
+    def test_join_content_simple(self):
+        content_bits = ['Works', 'like', 'join.']
+        expected_text = 'Works like join.'
+        self.assert_join_content(content_bits, expected_text)
 
     def assert_browser_lookup(self, name, browser_id, fixed_name, slug):
         lookup = self.visitor.browser_id_name_and_slug(name)

--- a/mdn/tests/test_tasks.py
+++ b/mdn/tests/test_tasks.py
@@ -128,7 +128,7 @@ class TestFetchMetaTask(TestCase):
         meta = fp.meta()
         issues = [[
             'failed_download', 0, 0,
-            {'url': meta.url(), 'status': 404, 'content': 'Not Found'}]]
+            {'url': meta.url(), 'status': 404, 'content': 'Not Found'}, None]]
         self.assertEqual(issues, fp.data['meta']['scrape']['issues'])
         self.assertEqual(meta.STATUS_ERROR, meta.status)
         self.assertEqual('Status 404, Content:\nNot Found', meta.raw)
@@ -142,7 +142,8 @@ class TestFetchMetaTask(TestCase):
         fp = FeaturePage.objects.get(id=self.fp.id)
         self.assertEqual(fp.STATUS_ERROR, fp.status)
         issues = [[
-            'bad_json', 0, 0, {'url': fp.url + '$json', 'content': text}]]
+            'bad_json', 0, 0,
+            {'url': fp.url + '$json', 'content': text}, None]]
         self.assertEqual(issues, fp.data['meta']['scrape']['issues'])
         meta = fp.meta()
         self.assertEqual(meta.STATUS_ERROR, meta.status)
@@ -315,7 +316,7 @@ class TestFetchTranslationTask(TestCase):
         url = trans.url() + '?raw'
         issue = [[
             'failed_download', 0, 0,
-            {'url': url, 'status': 404, 'content': content}]]
+            {'url': url, 'status': 404, 'content': content}, None]]
         self.assertEqual(issue, fp.data['meta']['scrape']['issues'])
 
 

--- a/mdn/tests/test_tasks.py
+++ b/mdn/tests/test_tasks.py
@@ -99,13 +99,11 @@ class TestFetchMetaTask(TestCase):
 
     def test_good_call(self):
         data = {
-            'locale': 'en-US',
+            'locale': 'en-US', 'title': 'display',
             'url': '/en-US/docs/Web/CSS/display',
             'translations': [{
-                'locale': 'es',
-                'url': '/es/docs/Web/CSS/display',
-            }],
-        }
+                'locale': 'es', 'title': 'display',
+                'url': '/es/docs/Web/CSS/display'}]}
         self.response.json.side_effect = None
         self.response.json.return_value = data
         self.mocked_fetch_all.side_effect = None
@@ -171,13 +169,11 @@ class TestFetchAllTranslationsTask(TestCase):
         meta = self.fp.meta()
         meta.status = meta.STATUS_FETCHED
         meta.raw = dumps({
-            'locale': 'en-US',
+            'locale': 'en-US', 'title': 'display',
             'url': '/en-US/docs/Web/CSS/display',
             'translations': [{
-                'locale': 'es',
-                'url': '/es/docs/Web/CSS/display',
-            }],
-        })
+                'locale': 'es', 'title': 'display',
+                'url': '/es/docs/Web/CSS/display'}]})
         meta.save()
 
         self.patcher_fetch_trans = mock.patch(
@@ -241,13 +237,11 @@ class TestFetchTranslationTask(TestCase):
         meta = self.fp.meta()
         meta.status = meta.STATUS_FETCHED
         meta.raw = dumps({
-            'locale': 'en-US',
+            'locale': 'en-US', 'title': 'display',
             'url': '/en-US/docs/Web/CSS/display',
             'translations': [{
-                'locale': 'es',
-                'url': '/es/docs/Web/CSS/display',
-            }],
-        })
+                'locale': 'es', 'title': 'display',
+                'url': '/es/docs/Web/CSS/display'}]})
         meta.save()
         self.fp.translatedcontent_set.create(locale='en-US')
         self.fp.translatedcontent_set.create(locale='es')

--- a/mdn/tests/test_views.py
+++ b/mdn/tests/test_views.py
@@ -109,6 +109,14 @@ class TestFeaturePageSearch(TestCase):
         next_url = reverse('feature_page_detail', kwargs={'pk': fp.id})
         self.assertRedirects(response, next_url)
 
+    def test_post_found_with_anchor(self):
+        fp = FeaturePage.objects.create(
+            url=self.mdn_url, feature_id=741, data='{"foo": "bar"}')
+        url = self.mdn_url + "#Browser_Compat"
+        response = self.client.get(self.url, {'url': url})
+        next_url = reverse('feature_page_detail', kwargs={'pk': fp.id})
+        self.assertRedirects(response, next_url)
+
     def test_not_found_with_perms(self):
         self.login_user(groups=['import-mdn'])
         response = self.client.get(self.url, {'url': self.mdn_url})

--- a/mdn/tests/test_views.py
+++ b/mdn/tests/test_views.py
@@ -83,12 +83,13 @@ class TestFeaturePageJSONView(TestCase):
     def test_get(self):
         feature_page = FeaturePage.objects.create(
             url="https://developer.mozilla.org/en-US/docs/Web/CSS/float",
-            feature_id=741, data={"foo": "bar"})
+            feature_id=741, raw_data='{"meta": {"scrape": {"issues": []}}}')
         url = reverse('feature_page_json', kwargs={'pk': feature_page.id})
         response = self.client.get(url)
         self.assertEqual(200, response.status_code)
         self.assertEqual('application/json', response['Content-Type'])
-        self.assertEqual(b'{"foo": "bar"}', response.content)
+        expected = b'{"meta": {"scrape": {"issues": []}}}'
+        self.assertEqual(expected, response.content)
 
 
 class TestFeaturePageSearch(TestCase):

--- a/mdn/tests/test_views.py
+++ b/mdn/tests/test_views.py
@@ -169,3 +169,10 @@ class TestFeaturePageResetView(TestCase):
         mocked_crawl.assertCalledOnce(self.fp.pk)
         fp = FeaturePage.objects.get(id=self.fp.id)
         self.assertEqual(fp.STATUS_STARTING, fp.status)
+
+
+class TestIssuesSummary(TestCase):
+    def test_get(self):
+        url = reverse('issues_summary')
+        response = self.client.get(url)
+        self.assertEqual(200, response.status_code)

--- a/mdn/urls.py
+++ b/mdn/urls.py
@@ -6,6 +6,7 @@ mdn_urlpatterns = patterns(
     url(r'^$', 'feature_page_list', name='feature_page_list'),
     url(r'^create$', 'feature_page_create', name='feature_page_create'),
     url(r'^search$', 'feature_page_search', name='feature_page_search'),
+    url(r'^issues$', 'issues_summary', name='issues_summary'),
     url(r'^(?P<pk>\d+)$', 'feature_page_detail', name='feature_page_detail'),
     url(r'^(?P<pk>\d+)\.json$', 'feature_page_json', name='feature_page_json'),
     url(r'^(?P<pk>\d+)/reset$', 'feature_page_reset',

--- a/mdn/urls.py
+++ b/mdn/urls.py
@@ -7,6 +7,7 @@ mdn_urlpatterns = patterns(
     url(r'^create$', 'feature_page_create', name='feature_page_create'),
     url(r'^search$', 'feature_page_search', name='feature_page_search'),
     url(r'^issues$', 'issues_summary', name='issues_summary'),
+    url(r'^issues/(?P<slug>.*)$', 'issues_detail', name='issues_detail'),
     url(r'^(?P<pk>\d+)$', 'feature_page_detail', name='feature_page_detail'),
     url(r'^(?P<pk>\d+)\.json$', 'feature_page_json', name='feature_page_json'),
     url(r'^(?P<pk>\d+)/reset$', 'feature_page_reset',

--- a/mdn/views.py
+++ b/mdn/views.py
@@ -153,7 +153,6 @@ class FeaturePageReParse(UpdateView):
         redirect = super(FeaturePageReParse, self).form_valid(form)
         assert self.object and self.object.id
         self.object.status = FeaturePage.STATUS_PARSING
-        self.object.issues.all().delete()
         self.object.reset_data()
         self.object.save()
         messages.add_message(

--- a/mdn/views.py
+++ b/mdn/views.py
@@ -150,6 +150,7 @@ class FeaturePageReParse(UpdateView):
         redirect = super(FeaturePageReParse, self).form_valid(form)
         assert self.object and self.object.id
         self.object.status = FeaturePage.STATUS_PARSING
+        self.object.issues.all().delete()
         self.object.reset_data()
         self.object.save()
         messages.add_message(

--- a/mdn/views.py
+++ b/mdn/views.py
@@ -4,6 +4,7 @@ from django.contrib.auth.decorators import user_passes_test
 from django.contrib import messages
 from django.core.urlresolvers import reverse
 from django.http import HttpResponseRedirect, JsonResponse
+from django.utils.six.moves.urllib.parse import urlparse, urlunparse
 from django.views.generic import DetailView, ListView, TemplateView
 from django.views.generic.base import TemplateResponseMixin, View
 from django.views.generic.detail import BaseDetailView
@@ -82,8 +83,10 @@ class SearchForm(forms.Form):
 
     def clean_url(self):
         data = self.cleaned_data['url']
-        validate_mdn_url(data)
-        return data
+        scheme, netloc, path, params, query, fragment = urlparse(data)
+        cleaned = urlunparse((scheme, netloc, path, '', '', ''))
+        validate_mdn_url(cleaned)
+        return cleaned
 
 
 class FeaturePageSearch(TemplateResponseMixin, View, FormMixin):

--- a/mdn/views.py
+++ b/mdn/views.py
@@ -4,12 +4,12 @@ from django.contrib.auth.decorators import user_passes_test
 from django.contrib import messages
 from django.core.urlresolvers import reverse
 from django.http import HttpResponseRedirect, JsonResponse
-from django.views.generic import DetailView, ListView
+from django.views.generic import DetailView, ListView, TemplateView
 from django.views.generic.base import TemplateResponseMixin, View
 from django.views.generic.detail import BaseDetailView
 from django.views.generic.edit import CreateView, FormMixin, UpdateView
 
-from .models import FeaturePage, validate_mdn_url
+from .models import FeaturePage, Issue, ISSUES, SEVERITIES, validate_mdn_url
 from .tasks import start_crawl, parse_page
 
 
@@ -187,6 +187,24 @@ class FeaturePageReset(UpdateView):
         return redirect
 
 
+class IssuesSummary(TemplateView):
+    template_name = "mdn/issues_summary.jinja2"
+
+    def get_context_data(self, **kwargs):
+        ctx = super(IssuesSummary, self).get_context_data(**kwargs)
+        issues = []
+        for slug, (severity_num, brief, lengthy) in ISSUES.items():
+            severity = SEVERITIES[severity_num]
+            target = Issue.objects.filter(slug=slug)
+            count = target.count()
+            examples = set(target.values_list('page_id', 'page__url')[:10])
+            issues.append((count, slug, severity, brief, examples))
+        issues.sort(reverse=True)
+        ctx['total_issues'] = Issue.objects.count()
+        ctx['issues'] = issues
+        return ctx
+
+
 feature_page_create = user_passes_test(can_create)(
     FeaturePageCreateView.as_view())
 feature_page_detail = FeaturePageDetailView.as_view()
@@ -197,3 +215,4 @@ feature_page_reset = user_passes_test(can_refresh)(
     FeaturePageReset.as_view())
 feature_page_reparse = user_passes_test(can_refresh)(
     FeaturePageReParse.as_view())
+issues_summary = IssuesSummary.as_view()

--- a/mdn/views.py
+++ b/mdn/views.py
@@ -13,6 +13,8 @@ from django.views.generic.edit import CreateView, FormMixin, UpdateView
 from .models import FeaturePage, Issue, ISSUES, SEVERITIES, validate_mdn_url
 from .tasks import start_crawl, parse_page
 
+DEV_PREFIX = 'https://developer.mozilla.org/en-US/docs/'
+
 
 def can_create(user):
     return user.has_perm('mdn.add_featurepage')
@@ -28,11 +30,29 @@ class FeaturePageListView(ListView):
     paginate_by = 50
 
     def get_queryset(self):
-        return FeaturePage.objects.order_by('feature_id')
+        qs = FeaturePage.objects.order_by('url')
+        topic = self.request.GET.get('topic')
+        if topic:
+            qs = qs.filter(url__startswith=DEV_PREFIX + topic)
+        return qs
 
     def get_context_data(self, **kwargs):
         ctx = super(FeaturePageListView, self).get_context_data(**kwargs)
         ctx['request'] = self.request
+        ctx['topic'] = self.request.GET.get('topic')
+        ctx['topics'] = sorted((
+            'Web/API',
+            'Web/Accessibility',
+            'Web/CSS',
+            'Web/Events',
+            'Web/Guide',
+            'Web/HTML',
+            'Web/JavaScript',
+            'Web/MathML',
+            'Web/SVG',
+            'Web/XPath',
+            'Web/XSLT',
+        ))
         return ctx
 
 
@@ -78,8 +98,7 @@ class FeaturePageJSONView(BaseDetailView):
 class SearchForm(forms.Form):
     url = forms.URLField(
         label='MDN URL',
-        widget=forms.URLInput(attrs={
-            'placeholder': "https://developer.mozilla.org/en-US/docs/..."}))
+        widget=forms.URLInput(attrs={'placeholder': DEV_PREFIX + '...'}))
 
     def clean_url(self):
         data = self.cleaned_data['url']
@@ -116,9 +135,29 @@ class FeaturePageSearch(TemplateResponseMixin, View, FormMixin):
 
     def form_valid(self, form):
         url = form.cleaned_data['url']
+        next_url = None
+
+        # Try loading a specific page
         try:
             fp = FeaturePage.objects.get(url=url)
         except FeaturePage.DoesNotExist:
+            pass
+        else:
+            next_url = reverse('feature_page_detail', kwargs={'pk': fp.pk})
+
+        # Try filtering by a subset of pages
+        if (not next_url) and (url.startswith(DEV_PREFIX)):
+            suburl = url
+            while suburl.endswith('/'):
+                suburl = suburl[:-1]
+            fp_start = FeaturePage.objects.filter(url__startswith=suburl)
+            if fp_start.exists():
+                topic = suburl.replace(DEV_PREFIX, '', 1)
+                next_url = reverse('feature_page_list')
+                next_url += '?topic={}'.format(topic)
+
+        # Page does not exist
+        if not next_url:
             msg = 'URL "%s" has not been scraped.' % url
             if can_create(self.request.user):
                 msg += ' Scrape it?'
@@ -127,8 +166,7 @@ class FeaturePageSearch(TemplateResponseMixin, View, FormMixin):
             else:
                 messages.add_message(self.request, messages.INFO, msg)
                 next_url = reverse('feature_page_list')
-        else:
-            next_url = reverse('feature_page_detail', kwargs={'pk': fp.pk})
+
         return HttpResponseRedirect(next_url)
 
 

--- a/mdn/views.py
+++ b/mdn/views.py
@@ -1,4 +1,6 @@
 """Views for MDN migration app."""
+from collections import Counter
+
 from django import forms
 from django.contrib.auth.decorators import user_passes_test
 from django.contrib import messages
@@ -237,11 +239,36 @@ class IssuesSummary(TemplateView):
             severity = SEVERITIES[severity_num]
             target = Issue.objects.filter(slug=slug)
             count = target.count()
-            examples = set(target.values_list('page_id', 'page__url')[:10])
-            issues.append((count, slug, severity, brief, examples))
+            raw = target.values_list('page__url', 'page_id')
+            examples = sorted(set(
+                (url.replace(DEV_PREFIX, '', 1), pid) for url, pid in raw))
+            issues.append((count, slug, severity, brief, examples[:5]))
         issues.sort(reverse=True)
         ctx['total_issues'] = Issue.objects.count()
         ctx['issues'] = issues
+        return ctx
+
+
+class IssuesDetail(TemplateView):
+    template_name = "mdn/issues_detail.jinja2"
+
+    def get_context_data(self, **kwargs):
+        ctx = super(IssuesDetail, self).get_context_data(**kwargs)
+        slug = self.kwargs['slug']
+        issues = Issue.objects.filter(slug=slug)
+        if issues.exists():
+            ctx['sample_issue'] = issues.first()
+            ctx['count'] = issues.count()
+            pages = Counter()
+            for url, pid in issues.values_list('page__url', 'page_id'):
+                key = (url.replace(DEV_PREFIX, '', 1), pid)
+                pages[key] += 1
+            ctx['pages'] = pages
+        else:
+            ctx['sample_issue'] = None
+            ctx['count'] = 0
+            ctx['pages'] = {}
+        ctx['slug'] = slug
         return ctx
 
 
@@ -256,3 +283,4 @@ feature_page_reset = user_passes_test(can_refresh)(
 feature_page_reparse = user_passes_test(can_refresh)(
     FeaturePageReParse.as_view())
 issues_summary = IssuesSummary.as_view()
+issues_detail = IssuesDetail.as_view()

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,17 +2,18 @@
 
 # Documentation
 Pygments==2.0.2
-sphinx-rtd-theme==0.1.7
-alabaster==0.7.3
+sphinx-rtd-theme==0.1.8
+alabaster==0.7.4
 Babel==1.3
 snowballstemmer==1.2.0
 Sphinx==1.3.1
 docutils==0.12
 
 # Multi-environment testing
-py==1.4.26
+py==1.4.27
+pluggy==0.3.0
 virtualenv==12.1.1
-tox==1.9.2
+tox==2.0.1
 
 # PEP8, PEP257 and static analysis
 mccabe==0.3
@@ -26,7 +27,7 @@ flake8-docstrings==0.2.1.post1
 check-manifest==0.24
 
 # Package QA
-pyroma==1.7
+pyroma==1.8.1
 
 # For ./manage.py runserver_plus
 Werkzeug==0.10.4
@@ -37,7 +38,7 @@ ipython==3.1.0
 ipdb==0.8
 
 # Debugging
-sqlparse==0.1.14
+sqlparse==0.1.15
 django-debug-toolbar==1.3.0
 
 # Test coverage

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -12,14 +12,14 @@ docutils==0.12
 # Multi-environment testing
 py==1.4.27
 pluggy==0.3.0
-virtualenv==12.1.1
+virtualenv==13.0.1
 tox==2.0.1
 
 # PEP8, PEP257 and static analysis
 mccabe==0.3
 pep8==1.5.7  # rq.filter: <1.6,>=1.5.7
 pyflakes==0.8.1
-flake8==2.4.0
+flake8==2.4.1
 pep257==0.5.0
 flake8-docstrings==0.2.1.post1
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -63,7 +63,7 @@ celery==3.1.17
 django-mptt==0.7.1
 
 # Sorted ManyToManyField
-django-sortedm2m==0.9.4
+django-sortedm2m==0.9.5
 
 # Cached instances for Django REST Framework
 drf-cached-instances==0.3.0
@@ -73,7 +73,9 @@ drf-cached-instances==0.3.0
 git+git://github.com/ottoyiu/django-cors-headers@b419817a2f#egg=django-cors-headers
 
 # Parsing Expression Grammar, for MDN scraping
-parsimonious==0.6.2
+# parsimonious==0.6.2
+# TravisCI is now using ascii as system encoding, breaking setup.py
+git+git://github.com/jwhitlock/parsimonious@68_fix_open#egg=parsimonious
 
 # Social loging support (Firefox Accounts)
 # python-openid >= 2.2.5  # Python 2.x - unused by app

--- a/requirements.txt
+++ b/requirements.txt
@@ -41,15 +41,14 @@ gunicorn==19.3.0
 psycopg2==2.6
 
 # Serve static files
-# static3 0.6.0 has utf-8 issue
-git+git://github.com/ryanhiebert/static3@tox-fix#egg=static3
+static3==0.6.1
 dj-static==0.0.6
 
 # Timezone info
 pytz==2015.4
 
 # Fast Memcache connections, and tell Heroku to install C dependencies
-pylibmc==1.4.2
+pylibmc==1.4.3
 django-pylibmc==0.6.0
 django-pylibmc-sasl==0.2.4
 
@@ -64,13 +63,14 @@ celery==3.1.18
 django-mptt==0.7.3
 
 # Sorted ManyToManyField
-django-sortedm2m==0.9.5
+django-sortedm2m==0.10.0
 
 # Cached instances for Django REST Framework
 drf-cached-instances==0.3.0
 
 # CORS headers in middleware
-# Head includes PR #51, waiting for release
+# django-cors-headers==1.1.0
+# Bug #50 (fixed by PR #51) prevents Firefox CORS
 git+git://github.com/ottoyiu/django-cors-headers@b419817a2f#egg=django-cors-headers
 
 # Parsing Expression Grammar, for MDN scraping
@@ -84,4 +84,4 @@ git+git://github.com/jwhitlock/parsimonious@68_fix_open#egg=parsimonious
 requests==2.7.0
 oauthlib==0.7.2
 requests-oauthlib==0.5.0
-django-allauth==0.19.1
+django-allauth==0.20.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,34 +2,34 @@
 
 # Django
 # 1.8 is waiting on django-simple-history
-Django==1.7.7  # rq.filter: >=1.7, <1.8
+Django==1.7.8  # rq.filter: >=1.7, <1.8
 
 # Better templates
 MarkupSafe==0.23
 Jinja2==2.7.3
-jingo==0.7
+jingo==0.7.1
 
 # Django REST Framework.
-djangorestframework==3.1.1
-Markdown==2.6.1
-django-filter==0.9.2
+djangorestframework==3.1.2
+Markdown==2.6.2
+django-filter==0.10.0
 
 # Django extensions
 six==1.9.0
-django-extensions==1.5.2
+django-extensions==1.5.5
 
 # JSON API interfaces for Django REST Framework
 git+git://github.com/jwhitlock/drf-json-api@v0.1d#egg=drf-json-api
 
 # History of changes to models
-django-simple-history==1.5.4
+django-simple-history==1.6.1
 
 # Configure database from env
 dj-database-url==0.3.0
 
 # Better test runner (included in settings)
 nose==1.3.6
-django-nose==1.3
+django-nose==1.4
 
 # Test Mocking, included in Python 3.3
 mock==1.0.1
@@ -41,26 +41,27 @@ gunicorn==19.3.0
 psycopg2==2.6
 
 # Serve static files
-static3==0.5.1
+# static3 0.6.0 has utf-8 issue
+git+git://github.com/ryanhiebert/static3@tox-fix#egg=static3
 dj-static==0.0.6
 
 # Timezone info
-pytz==2015.2
+pytz==2015.4
 
 # Fast Memcache connections, and tell Heroku to install C dependencies
-pylibmc==1.4.1
+pylibmc==1.4.2
 django-pylibmc==0.6.0
 django-pylibmc-sasl==0.2.4
 
 # Celery - async task management
-billiard==3.3.0.19
+billiard==3.3.0.20
 amqp==1.4.6
 anyjson==0.3.3
-kombu==3.0.24
-celery==3.1.17
+kombu==3.0.26
+celery==3.1.18
 
 # Modified Preorder Tree Traversal
-django-mptt==0.7.1
+django-mptt==0.7.3
 
 # Sorted ManyToManyField
 django-sortedm2m==0.9.5
@@ -80,7 +81,7 @@ git+git://github.com/jwhitlock/parsimonious@68_fix_open#egg=parsimonious
 # Social loging support (Firefox Accounts)
 # python-openid >= 2.2.5  # Python 2.x - unused by app
 # python3-openid >= 3.0.1 # Python 3.x - unused by app
-requests==2.6.0
+requests==2.7.0
 oauthlib==0.7.2
-requests-oauthlib==0.4.2
+requests-oauthlib==0.5.0
 django-allauth==0.19.1

--- a/tools/client.py
+++ b/tools/client.py
@@ -218,55 +218,16 @@ class Client(object):
 
 if __name__ == "__main__":
     from math import log10, trunc
-    import argparse
-    import sys
+    from common import ToolParser
 
-    description = 'Demo client with resource count'
-    parser = argparse.ArgumentParser(description=description)
-    parser.add_argument(
-        '-a', '--api',
-        help='Base URL of the API (default: http://localhost:8000)',
-        default="http://localhost:8000")
-    parser.add_argument(
-        '-v', '--verbose', action="store_true",
-        help='Print extra debug information')
-    parser.add_argument(
-        '-q', '--quiet', action="store_true",
-        help='Only print warnings')
-    parser.add_argument(
-        '--all-data', action="store_true",
-        help='Import all the data, rather than a subset')
+    parser = ToolParser(
+        description='Demo client with resource count', include=['api'],
+        logger=logger)
+
     args = parser.parse_args()
-
-    # Setup logging
-    verbose = args.verbose
-    quiet = args.quiet
-    console = logging.StreamHandler(sys.stderr)
-    formatter = logging.Formatter('%(levelname)s - %(message)s')
-    logger_name = 'tools'
-    fmat = '%(levelname)s - %(message)s'
-    if quiet:
-        level = logging.WARNING
-    elif verbose:
-        level = logging.DEBUG
-        logger_name = ''
-        fmat = '%(name)s - %(levelname)s - %(message)s'
-    else:
-        level = logging.INFO
-    formatter = logging.Formatter(fmat)
-    console.setLevel(level)
-    console.setFormatter(formatter)
-    logger = logging.getLogger(logger_name)
-    logger.setLevel(level)
-    logger.addHandler(console)
-
-    # Parse arguments
     api = args.api
-    if api.endswith('/'):
-        api = api[:-1]
     logger.info("Counting resources on %s" % api)
 
-    # Get counts
     client = Client(api)
     resources = [
         'browsers', 'versions', 'features', 'supports', 'specifications',

--- a/tools/common.py
+++ b/tools/common.py
@@ -1,0 +1,275 @@
+"""Common tool code."""
+from __future__ import print_function
+
+import argparse
+import codecs
+import getpass
+import logging
+import os.path
+import string
+import sys
+
+import requests
+
+from client import Client
+from resources import CollectionChangeset
+
+_my_dir = os.path.dirname(os.path.realpath(__file__))
+_data_dir = os.path.realpath(os.path.join(_my_dir, '..', 'data'))
+
+try:
+    input = raw_input  # Get the Py2 raw_input
+except NameError:
+    pass  # We're in Py3
+
+
+class ToolParser(argparse.ArgumentParser):
+    """Parser with common options."""
+
+    class StripTrailingSlash(argparse.Action):
+        def __call__(self, parser, namespace, values, option_string=None):
+            if values.endswith('/'):
+                values = values[:-1]
+            setattr(namespace, self.dest, values)
+
+    def __init__(
+            self, logger=None, include=None, *args, **kwargs):
+        """Initialize the parser.
+
+        Same as ArgumentParser, but with additional options:
+        logger - Initialize the logger with -v/-q options
+        include - list of additional options to include.  Supported:
+            api - Add --api option
+            user - Add --user option
+            password - Add --password option
+            data - Add --data option
+        """
+        super(ToolParser, self).__init__(*args, **kwargs)
+
+        self.include_set = set(include or [])
+        valid = set(['api', 'user', 'password', 'data'])
+        if self.include_set - valid:
+            raise ValueError(
+                'Unknown include items: {}'.format(self.include_set - valid))
+
+        if 'api' in self.include_set:
+            self.add_argument(
+                '-a', '--api',
+                help='Base URL of the API (default: http://localhost:8000)',
+                default="http://localhost:8000",
+                action=ToolParser.StripTrailingSlash)
+
+        if 'user' in self.include_set:
+            self.add_argument(
+                '-u', '--user',
+                help='Username on API (default: prompt for username)')
+
+        if 'password' in self.include_set:
+            self.add_argument(
+                '-p', '--password',
+                help='Password on API (default: prompt for password)')
+
+        if logger:
+            self.logger = logger
+            self.add_argument(
+                '-v', '--verbose', action="store_true",
+                help='Print extra debug information')
+            self.add_argument(
+                '-q', '--quiet', action="store_true",
+                help='Only print warnings')
+
+        if 'data' in self.include_set:
+            self.add_argument(
+                '-d', '--data', default=_data_dir,
+                action=ToolParser.StripTrailingSlash,
+                help='Output data folder (default: %s)' % _data_dir)
+
+    def parse_args(self, *args, **kwargs):
+        args = super(ToolParser, self).parse_args(*args, **kwargs)
+
+        # Setup logger w/ options
+        if self.logger:
+            verbose = args.verbose
+            quiet = args.quiet
+            console = logging.StreamHandler(sys.stderr)
+            formatter = logging.Formatter('%(levelname)s - %(message)s')
+            fmat = '%(levelname)s - %(message)s'
+            logger_name = 'tools'
+            if quiet:
+                level = logging.WARNING
+            elif verbose:
+                level = logging.DEBUG
+                logger_name = ''
+                fmat = '%(name)s - %(levelname)s - %(message)s'
+            else:
+                level = logging.INFO
+            formatter = logging.Formatter(fmat)
+            console.setLevel(level)
+            console.setFormatter(formatter)
+            logger = logging.getLogger(logger_name)
+            logger.setLevel(level)
+            logger.addHandler(console)
+
+        return args
+
+
+class Tool(object):
+    """A tool for working with the API."""
+    logger_name = 'tools'
+    parser_options = []
+
+    def __init__(self):
+        """Initialize the tool."""
+        self.api = None
+        self._client = None
+        self.logger = logging.getLogger(self.logger_name)
+        self.data = 'data'
+
+    def cached_download(self, filename, url):
+        """Download a file, then serve it from the cache."""
+        path = self.data_file(filename)
+        if not os.path.exists(path):
+            self.logger.info("Downloading " + path)
+            r = requests.get(url)
+            with codecs.open(path, 'wb', 'utf8') as f:
+                f.write(r.text)
+        else:
+            self.logger.info("Using existing " + path)
+
+        with codecs.open(path, 'r', 'utf8') as f:
+            content = f.read()
+        return content
+
+    @property
+    def client(self):
+        """Return an API Client."""
+        assert self.api, 'Must set API first'
+        if not self._client:
+            self._client = Client(self.api)
+        return self._client
+
+    def confirm_changes(self, changeset):
+        """Ask the user to confirm a changeset."""
+        while True:
+            choice = input("Make these changes? (Y/N/D for details) ")
+            if choice.upper() == 'Y':
+                return True
+            elif choice.upper() == 'N':
+                return False
+            elif choice.upper() == 'D':
+                print(changeset.summarize())
+            else:
+                print("Please type Y or N or D.")
+
+    def data_file(self, filename):
+        """Return the path to a data file."""
+        return os.path.join(self.data, filename)
+
+    def get_parser(self):
+        """Construct the command line parser."""
+        description = self.__doc__.split('\n')[0]
+        parser = ToolParser(
+            description=description, logger=self.logger,
+            include=self.parser_options)
+        return parser
+
+    def get_password(self):
+        """Get the password, prompting if needed."""
+        if not getattr(self, 'password'):
+            self.password = getpass.getpass("API password: ")
+        return self.password
+
+    def get_user(self):
+        """Get the user, prompting if needed."""
+        if not getattr(self, 'user'):
+            self.user = input("API username: ")
+        return self.user
+
+    def init_from_command_line(self):
+        """Initialize the tool from the command line."""
+        parser = self.get_parser()
+        args = parser.parse_args()
+        for key, value in vars(args).items():
+            setattr(self, key, value)
+        return args
+
+    def login(self):
+        user = self.get_user()
+        password = self.get_password()
+        self.client.login(user, password)
+
+    def report_changes(self, counts):
+        if counts:
+            self.logger.info("Changes complete. Counts:")
+            for resource_type, changes in counts.items():
+                c_new = changes.get('new', 0)
+                c_deleted = changes.get('deleted', 0)
+                c_changed = changes.get('changed', 0)
+                c_text = []
+                if c_new:
+                    c_text.append("%d new" % c_new)
+                if c_deleted:
+                    c_text.append("%d deleted" % c_deleted)
+                if c_changed:
+                    c_text.append("%d changed" % c_changed)
+                if c_text:
+                    self.logger.info("  %s: %s" % (
+                        resource_type.title(), ', '.join(c_text)))
+        else:
+            self.logger.info("No data uploaded.")
+
+    def run(self, *args, **kwargs):
+        """Run the tool."""
+        raise NotImplementedError('run not implemented')
+
+    def slugify(self, word, attempt=0):
+        """Slugify a word, mixing in an attempt count as needed."""
+        raw = word.lower().encode('utf-8')
+        out = []
+        acceptable = string.ascii_lowercase + string.digits + '_-'
+        for c in raw:
+            if c in acceptable:
+                out += str(c)
+            else:
+                out += '_'
+        slugged = ''.join(out)
+        while '__' in slugged:
+            slugged = slugged.replace('__', '_')
+        if attempt:
+            suffix = str(attempt)
+        else:
+            suffix = ""
+        return slugged[slice(50 - len(suffix))] + suffix
+
+    def sync_changes(self, api_collection, local_collection):
+        """Sync changes to a remote collection from a local collection
+
+        Returns a dictionary counting the new, changed, and deleted items,
+        or an empty dictionary if no changes.
+        """
+        self.logger.info('Looking for changes...')
+        changeset = CollectionChangeset(api_collection, local_collection)
+        delta = changeset.changes
+
+        if delta['new'] or delta['changed'] or delta['deleted']:
+            self.logger.info(
+                'Changes detected: %d new, %d changed, %d deleted, %d same.',
+                len(delta['new']), len(delta['changed']),
+                len(delta['deleted']), len(delta['same']))
+            confirmed = self.confirm_changes(changeset)
+            if not confirmed:
+                return {}
+        else:
+            self.logger.info('No changes')
+            return {}
+
+        return changeset.change_original_collection()
+
+    def unique_slugify(self, word, existing):
+        slug = self.slugify(word)
+        attempt = 0
+        while slug in existing:
+            attempt += 1
+            slug = self.slugify(word, attempt)
+        existing.add(slug)
+        return slug

--- a/tools/download_data.py
+++ b/tools/download_data.py
@@ -1,109 +1,49 @@
 #!/usr/bin/env python
-
-from __future__ import print_function
-
 import codecs
 import json
-import logging
-import os.path
-import sys
 
-from client import Client
-
-logger = logging.getLogger('tools.download_data')
-
-resources = [
-    'browsers',
-    'versions',
-    'features',
-    'supports',
-    'specifications',
-    'maturities',
-    'sections',
-]
+from common import Tool
 
 
-def download_data(client, base_dir=''):
-    """Download data from the API"""
-    counts = {}
-    for resource in resources:
-        # Get data from API
-        data = client.get_resource_collection(resource)
-        logger.info("Downloaded %d %s.", len(data[resource]), resource)
-        counts[resource] = len(data[resource])
+class DownloadData(Tool):
+    """Download data from the API."""
+    logger_name = 'tools.download_data'
+    parser_options = ['api', 'data']
 
-        # Remove history relations
-        for item in data[resource]:
-            del item['links']['history']
-            del item['links']['history_current']
-        if 'links' in data:
-            del data['links']['%s.history' % resource]
-            del data['links']['%s.history_current' % resource]
+    def run(self, *args, **kwargs):
+        counts = {}
+        resources = [
+            'browsers', 'versions', 'features', 'supports', 'specifications',
+            'maturities', 'sections']
+        for resource in resources:
+            # Get data from API
+            data = self.client.get_resource_collection(resource)
+            self.logger.info(
+                "Downloaded {} {}".format(len(data[resource]), resource))
+            counts[resource] = len(data[resource])
 
-        # Write to a file
-        filepath = os.path.join(base_dir, '%s.json' % resource)
-        with codecs.open(filepath, 'w', 'utf8') as f:
-            json.dump(data, f, indent=4, separators=(',', ': '))
+            # Remove history relations
+            for item in data[resource]:
+                del item['links']['history']
+                del item['links']['history_current']
+            if 'links' in data:
+                del data['links'][resource + '.history']
+                del data['links'][resource + '.history_current']
 
-    return counts
+            # Write to a file
+            filepath = self.data_file('{}.json'.format(resource))
+            with codecs.open(filepath, 'w', 'utf8') as f:
+                json.dump(data, f, indent=4, separators=(',', ': '))
+        return counts
+
 
 if __name__ == '__main__':
-    import argparse
-    description = 'Download data from API.'
-    parser = argparse.ArgumentParser(description=description)
-    parser.add_argument(
-        '-a', '--api',
-        help='Base URL of the API (default: http://localhost:8000)',
-        default="http://localhost:8000")
-    parser.add_argument(
-        '-v', '--verbose', action="store_true",
-        help='Print extra debug information')
-    parser.add_argument(
-        '-q', '--quiet', action="store_true",
-        help='Only print warnings')
-    parser.add_argument(
-        '-d', '--data', default='data',
-        help='Output data folder (default: data)')
-    args = parser.parse_args()
-
-    # Setup logging
-    verbose = args.verbose
-    quiet = args.quiet
-    console = logging.StreamHandler(sys.stderr)
-    formatter = logging.Formatter('%(levelname)s - %(message)s')
-    fmat = '%(levelname)s - %(message)s'
-    logger_name = 'tools'
-    if quiet:
-        level = logging.WARNING
-    elif verbose:
-        level = logging.DEBUG
-        logger_name = ''
-        fmat = '%(name)s - %(levelname)s - %(message)s'
-    else:
-        level = logging.INFO
-    formatter = logging.Formatter(fmat)
-    console.setLevel(level)
-    console.setFormatter(formatter)
-    logger = logging.getLogger(logger_name)
-    logger.setLevel(level)
-    logger.addHandler(console)
-
-    # Parse arguments
-    api = args.api
-    if api.endswith('/'):
-        api = api[:-1]
-    data = args.data
-    if data.endswith('/'):
-        data = data[:-1]
-    logger.info("Downloading data from %s to %s", api, data)
-
-    # Initialize client
-    client = Client(api)
-
-    # Load data
-    counts = download_data(client, data)
-
+    tool = DownloadData()
+    tool.init_from_command_line()
+    tool.logger.info(
+        "Downloading data from {tool.api} to {tool.data}".format(tool=tool))
+    counts = tool.run()
     if counts:
-        logger.info("Download complete.")
+        tool.logger.info("Download complete.")
     else:
-        logger.info("No data downloaded.")
+        tool.logger.info("No data downloaded.")

--- a/tools/gather_import_issues.py
+++ b/tools/gather_import_issues.py
@@ -6,19 +6,10 @@ from collections import Counter
 from json import dumps
 from HTMLParser import HTMLParser
 import csv
-import logging
-import os.path
 import re
-import sys
 import time
 
-from client import Client
-
-logger = logging.getLogger('tools.gather_import_issues')
-my_dir = os.path.dirname(os.path.realpath(__file__))
-data_dir = os.path.realpath(os.path.join(my_dir, '..', 'data'))
-BY_URL_CSV_FILENAME = os.path.join(data_dir, 'import_issues_by_url.csv')
-BY_ERRORS_CSV_FILENAME = os.path.join(data_dir, 'import_issue_counts.csv')
+from common import Tool
 
 
 class GatherLinks(HTMLParser):
@@ -40,138 +31,107 @@ class GatherLinks(HTMLParser):
         return ["/importer/%d.json" % i for i in sorted(self.import_ids)]
 
 
-def gather_import_issues(client, by_url_csv, by_issue_csv):
-    issue_rows = download_issues(client)
-    issue_counts = Counter()
+class GatherImportIssues(Tool):
+    """Gather import issues into CSVs."""
+    logger_name = 'tools.gather_import_issues'
+    parser_options = ['api', 'data']
 
-    # Write by-url CSV and count issues
-    by_url_writer = csv.writer(by_url_csv)
-    by_url_writer.writerow(
-        ["MDN Slug", "Import URL", "Issue Slug", "Source Start", "Source End",
-         "Params"])
-    for row in issue_rows:
-        err = row[4]
-        issue_counts[err] += 1
-        by_url_writer.writerow(row)
+    def run(self, by_url_csv, by_issue_csv, *args, **kwargs):
+        issue_rows = self.download_issues()
+        issue_counts = Counter()
 
-    # Write by_issue CSV
-    by_issue_writer = csv.writer(by_issue_csv)
-    by_issue_writer.writerow(["Count", "Issue"])
-    for err, count in issue_counts.most_common():
-        by_issue_writer.writerow((count, err))
+        # Write by-url CSV and count issues
+        by_url_writer = csv.writer(by_url_csv)
+        by_url_writer.writerow([
+            "MDN Slug", "Import URL", "Issue Slug", "Source Start",
+            "Source End", "Params"])
+        for row in issue_rows:
+            err = row[4]
+            issue_counts[err] += 1
+            by_url_writer.writerow(row)
 
-    return {
-        'total': len(issue_rows),
-        'unique': len(issue_counts),
-    }
+        # Write by_issue CSV
+        by_issue_writer = csv.writer(by_issue_csv)
+        by_issue_writer.writerow(["Count", "Issue"])
+        for err, count in issue_counts.most_common():
+            by_issue_writer.writerow((count, err))
 
+        return {
+            'total': len(issue_rows),
+            'unique': len(issue_counts),
+        }
 
-def download_issues(client):
-    # Gather import links
-    start = time.time()
-    logger.info("Gathering import URLs from %s...", client.base_url)
-    page = 1
-    parser = GatherLinks()
-    status = 200
-    while status == 200:
-        index_url = client.base_url + '/importer/'
-        index_resp = client.session.get(index_url, params={'page': page})
-        status = index_resp.status_code
-        if status == 200:
-            parser.feed(index_resp.text)
-            page += 1
-    import_urls = parser.get_urls()
-    total_urls = len(import_urls)
-    end = time.time()
-    logger.info("Found %d import URLs in %0.1fs", total_urls, end - start)
+    def download_issues(self):
+        """Download issues from API."""
+        assert self.api, 'Must set api to API base URL'
 
-    # Gather issues
-    issue_rows = []
-    start = time.time()
-    for url_count, raw_url in enumerate(import_urls):
-        url = client.base_url + raw_url
-        human_import_url = url.replace('.json', '')
-        resp = client.session.get(url)
-        resp.raise_for_status()
-        resp_json = resp.json()
-        mdn_uri = resp_json['features']['mdn_uri']['en']
-        mdn_prefix = 'https://developer.mozilla.org/en-US/docs/'
-        assert mdn_uri.startswith(mdn_prefix)
-        mdn_slug = mdn_uri.replace(mdn_prefix, '', 1)
-        issues = resp_json['meta']['scrape']['issues']
-        for issue in issues:
-            assert isinstance(issue, list)
-            issue_slug, start_pos, end_pos, raw_params = issue
-            params = dumps(raw_params)
-            issue_rows.append(
-                (mdn_slug, human_import_url, issue_slug, start_pos, end_pos,
-                 params))
+        # Gather import links
+        start = time.time()
+        self.logger.info("Gathering import URLs from %s...", self.api)
+        page = 1
+        parser = GatherLinks()
+        status = 200
+        while status == 200:
+            index_url = self.api + '/importer/'
+            index_resp = self.client.session.get(
+                index_url, params={'page': page})
+            status = index_resp.status_code
+            if status == 200:
+                parser.feed(index_resp.text)
+                page += 1
+        import_urls = parser.get_urls()
+        total_urls = len(import_urls)
         end = time.time()
-        if (end - start) > 15:
-            percent = 100.0 * (1 - (total_urls - url_count + 1.0) / total_urls)
-            logger.info(
-                "Found %d issues in %d imports (%d%%)",
-                len(issue_rows), url_count + 1, percent)
-            start = time.time()
+        self.logger.info(
+            "Found %d import URLs in %0.1fs", total_urls, end - start)
 
-    return issue_rows
+        # Gather issues
+        issue_rows = []
+        start = time.time()
+        for url_count, raw_url in enumerate(import_urls):
+            url = self.api + raw_url
+            human_import_url = url.replace('.json', '')
+            resp = self.client.session.get(url)
+            resp.raise_for_status()
+            resp_json = resp.json()
+            mdn_uri = resp_json['features']['mdn_uri']['en']
+            mdn_prefix = 'https://developer.mozilla.org/en-US/docs/'
+            assert mdn_uri.startswith(mdn_prefix)
+            mdn_slug = mdn_uri.replace(mdn_prefix, '', 1)
+            issues = resp_json['meta']['scrape']['issues']
+            for issue in issues:
+                assert isinstance(issue, list)
+                issue_slug, start_pos, end_pos, raw_params = issue
+                params = dumps(raw_params)
+                issue_rows.append(
+                    (mdn_slug, human_import_url, issue_slug, start_pos,
+                     end_pos, params))
+            end = time.time()
+            if (end - start) > 15:
+                percent = (
+                    100.0 * (1 - (total_urls - url_count + 1.0) / total_urls))
+                self.logger.info(
+                    "Found %d issues in %d imports (%d%%)",
+                    len(issue_rows), url_count + 1, percent)
+                start = time.time()
+
+        return issue_rows
 
 
 if __name__ == '__main__':
-    import argparse
-    description = 'Gather import issues into CSVs.'
-    parser = argparse.ArgumentParser(description=description)
-    parser.add_argument(
-        '-a', '--api',
-        help='Base URL of the API (default: http://localhost:8000)',
-        default="http://localhost:8000")
-    parser.add_argument(
-        '-v', '--verbose', action="store_true",
-        help='Print extra debug information')
-    parser.add_argument(
-        '-q', '--quiet', action="store_true",
-        help='Only print warnings')
-    args = parser.parse_args()
+    tool = GatherImportIssues()
+    tool.init_from_command_line()
+    tool.logger.info("Loading import issues from {tool.api}".format(tool=tool))
 
-    # Setup logging
-    verbose = args.verbose
-    quiet = args.quiet
-    console = logging.StreamHandler(sys.stderr)
-    formatter = logging.Formatter('%(levelname)s - %(message)s')
-    logger_name = 'tools'
-    fmat = '%(levelname)s - %(message)s'
-    if quiet:
-        level = logging.WARNING
-    elif verbose:
-        level = logging.DEBUG
-        logger_name = ''
-        fmat = '%(name)s - %(levelname)s - %(message)s'
-    else:
-        level = logging.INFO
-    formatter = logging.Formatter(fmat)
-    console.setLevel(level)
-    console.setFormatter(formatter)
-    logger = logging.getLogger(logger_name)
-    logger.setLevel(level)
-    logger.addHandler(console)
-
-    # Parse arguments
-    api = args.api
-    if api.endswith('/'):
-        api = api[:-1]
-    logger.info("Loading importer issues from %s" % api)
-
-    # Initialize client
-    client = Client(api)
-
-    # Gather issues and write to CSVs
     counts = {}
     by_url_csv = None
     by_issue_csv = None
+    by_url_file = tool.data_file('import_issues_by_url.csv')
+    by_issue_file = tool.data_file('import_issue_counts.csv')
     try:
-        by_url_csv = open(BY_URL_CSV_FILENAME, "wb")
-        by_issue_csv = open(BY_ERRORS_CSV_FILENAME, "wb")
-        counts = gather_import_issues(client, by_url_csv, by_issue_csv)
+        by_url_csv = open(by_url_file, "wb")
+        by_issue_csv = open(by_issue_file, "wb")
+        counts = tool.run(by_url_csv, by_issue_csv)
     finally:
         if by_issue_csv:
             by_issue_csv.close()
@@ -181,9 +141,9 @@ if __name__ == '__main__':
     if counts:
         c_unique = counts.get('unique', 0)
         c_total = counts.get('total', 0)
-        logger.info(
+        tool.logger.info(
             "Issues collected: %d unique (%d total)", c_unique, c_total)
-        logger.info("Issue details in %s", BY_URL_CSV_FILENAME)
-        logger.info("Issue counts in %s", BY_ERRORS_CSV_FILENAME)
+        tool.logger.info("Issue details in %s", by_url_file)
+        tool.logger.info("Issue counts in %s", by_issue_file)
     else:
-        logger.info("No issues found.")
+        tool.logger.info("No issues found.")

--- a/tools/gather_import_issues.py
+++ b/tools/gather_import_issues.py
@@ -3,6 +3,7 @@
 from __future__ import print_function
 
 from collections import Counter
+from json import dumps
 from HTMLParser import HTMLParser
 import csv
 import logging
@@ -13,11 +14,11 @@ import time
 
 from client import Client
 
-logger = logging.getLogger('tools.gather_import_errors')
+logger = logging.getLogger('tools.gather_import_issues')
 my_dir = os.path.dirname(os.path.realpath(__file__))
 data_dir = os.path.realpath(os.path.join(my_dir, '..', 'data'))
-BY_URL_CSV_FILENAME = os.path.join(data_dir, 'import_errors_by_url.csv')
-BY_ERRORS_CSV_FILENAME = os.path.join(data_dir, 'import_error_counts.csv')
+BY_URL_CSV_FILENAME = os.path.join(data_dir, 'import_issues_by_url.csv')
+BY_ERRORS_CSV_FILENAME = os.path.join(data_dir, 'import_issue_counts.csv')
 
 
 class GatherLinks(HTMLParser):
@@ -39,33 +40,33 @@ class GatherLinks(HTMLParser):
         return ["/importer/%d.json" % i for i in sorted(self.import_ids)]
 
 
-def gather_import_errors(client, by_url_csv, by_error_csv):
-    error_rows = download_errors(client)
-    error_counts = Counter()
+def gather_import_issues(client, by_url_csv, by_issue_csv):
+    issue_rows = download_issues(client)
+    issue_counts = Counter()
 
-    # Write by-url CSV and count errors
+    # Write by-url CSV and count issues
     by_url_writer = csv.writer(by_url_csv)
     by_url_writer.writerow(
-        ["MDN Slug", "Import URL", "Source Start", "Source End", "Error",
-         "Rule"])
-    for row in error_rows:
+        ["MDN Slug", "Import URL", "Issue Slug", "Source Start", "Source End",
+         "Params"])
+    for row in issue_rows:
         err = row[4]
-        error_counts[err] += 1
+        issue_counts[err] += 1
         by_url_writer.writerow(row)
 
-    # Write by_error CSV
-    by_error_writer = csv.writer(by_error_csv)
-    by_error_writer.writerow(["Count", "Error"])
-    for err, count in error_counts.most_common():
-        by_error_writer.writerow((count, err))
+    # Write by_issue CSV
+    by_issue_writer = csv.writer(by_issue_csv)
+    by_issue_writer.writerow(["Count", "Issue"])
+    for err, count in issue_counts.most_common():
+        by_issue_writer.writerow((count, err))
 
     return {
-        'total': len(error_rows),
-        'unique': len(error_counts),
+        'total': len(issue_rows),
+        'unique': len(issue_counts),
     }
 
 
-def download_errors(client):
+def download_issues(client):
     # Gather import links
     start = time.time()
     logger.info("Gathering import URLs from %s...", client.base_url)
@@ -84,8 +85,8 @@ def download_errors(client):
     end = time.time()
     logger.info("Found %d import URLs in %0.1fs", total_urls, end - start)
 
-    # Gather errors
-    error_rows = []
+    # Gather issues
+    issue_rows = []
     start = time.time()
     for url_count, raw_url in enumerate(import_urls):
         url = client.base_url + raw_url
@@ -97,34 +98,28 @@ def download_errors(client):
         mdn_prefix = 'https://developer.mozilla.org/en-US/docs/'
         assert mdn_uri.startswith(mdn_prefix)
         mdn_slug = mdn_uri.replace(mdn_prefix, '', 1)
-        errors = resp_json['meta']['scrape']['raw']['errors']
-        for err in errors:
-            if isinstance(err, list):
-                start_pos, end_pos, msg = err[:3]
-                if len(err) == 4:
-                    rule = err[3]
-                else:
-                    rule = ""
-            else:
-                msg = err
-                start_pos = end_pos = rule = ''
-            error_rows.append(
-                (mdn_slug, human_import_url, start_pos, end_pos,
-                 msg.encode('utf-8'), rule))
+        issues = resp_json['meta']['scrape']['issues']
+        for issue in issues:
+            assert isinstance(issue, list)
+            issue_slug, start_pos, end_pos, raw_params = issue
+            params = dumps(raw_params)
+            issue_rows.append(
+                (mdn_slug, human_import_url, issue_slug, start_pos, end_pos,
+                 params))
         end = time.time()
         if (end - start) > 15:
-            percent = 100.0 * (total_urls - url_count + 1.0) / total_urls
+            percent = 100.0 * (1 - (total_urls - url_count + 1.0) / total_urls)
             logger.info(
-                "Found %d errors in %d imports (%d%%)",
-                len(error_rows), url_count + 1, percent)
+                "Found %d issues in %d imports (%d%%)",
+                len(issue_rows), url_count + 1, percent)
             start = time.time()
 
-    return error_rows
+    return issue_rows
 
 
 if __name__ == '__main__':
     import argparse
-    description = 'Gather import errors into CSVs.'
+    description = 'Gather import issues into CSVs.'
     parser = argparse.ArgumentParser(description=description)
     parser.add_argument(
         '-a', '--api',
@@ -164,22 +159,22 @@ if __name__ == '__main__':
     api = args.api
     if api.endswith('/'):
         api = api[:-1]
-    logger.info("Loading importer errors from %s" % api)
+    logger.info("Loading importer issues from %s" % api)
 
     # Initialize client
     client = Client(api)
 
-    # Gather errors and write to CSVs
+    # Gather issues and write to CSVs
     counts = {}
     by_url_csv = None
-    by_error_csv = None
+    by_issue_csv = None
     try:
         by_url_csv = open(BY_URL_CSV_FILENAME, "wb")
-        by_error_csv = open(BY_ERRORS_CSV_FILENAME, "wb")
-        counts = gather_import_errors(client, by_url_csv, by_error_csv)
+        by_issue_csv = open(BY_ERRORS_CSV_FILENAME, "wb")
+        counts = gather_import_issues(client, by_url_csv, by_issue_csv)
     finally:
-        if by_error_csv:
-            by_error_csv.close()
+        if by_issue_csv:
+            by_issue_csv.close()
         if by_url_csv:
             by_url_csv.close()
 
@@ -187,8 +182,8 @@ if __name__ == '__main__':
         c_unique = counts.get('unique', 0)
         c_total = counts.get('total', 0)
         logger.info(
-            "Errors collected: %d unique (%d total)", c_unique, c_total)
-        logger.info("Error details in %s", BY_URL_CSV_FILENAME)
-        logger.info("Error counts in %s", BY_ERRORS_CSV_FILENAME)
+            "Issues collected: %d unique (%d total)", c_unique, c_total)
+        logger.info("Issue details in %s", BY_URL_CSV_FILENAME)
+        logger.info("Issue counts in %s", BY_ERRORS_CSV_FILENAME)
     else:
-        logger.info("No errors found.")
+        logger.info("No issues found.")

--- a/tools/gather_import_issues.py
+++ b/tools/gather_import_issues.py
@@ -101,7 +101,7 @@ class GatherImportIssues(Tool):
             issues = resp_json['meta']['scrape']['issues']
             for issue in issues:
                 assert isinstance(issue, list)
-                issue_slug, start_pos, end_pos, raw_params = issue
+                issue_slug, start_pos, end_pos, raw_params = issue[:4]
                 params = dumps(raw_params)
                 issue_rows.append(
                     (mdn_slug, human_import_url, issue_slug, start_pos,

--- a/tools/gather_import_issues.py
+++ b/tools/gather_import_issues.py
@@ -46,7 +46,7 @@ class GatherImportIssues(Tool):
             "MDN Slug", "Import URL", "Issue Slug", "Source Start",
             "Source End", "Params"])
         for row in issue_rows:
-            err = row[4]
+            err = row[2]
             issue_counts[err] += 1
             by_url_writer.writerow(row)
 

--- a/tools/import_mdn.py
+++ b/tools/import_mdn.py
@@ -1,157 +1,96 @@
 #!/usr/bin/env python
-
-from __future__ import print_function
-
-import getpass
-import logging
-import os.path
-import sys
 import time
 
-from client import Client
+from common import Tool
 from resources import Collection
 
-try:
-    input = raw_input  # Get the Py2 raw_input
-except NameError:
-    pass  # We're in Py3
 
-logger = logging.getLogger('tools.import_mdn')
-my_dir = os.path.dirname(os.path.realpath(__file__))
-data_dir = os.path.realpath(os.path.join(my_dir, '..', 'data'))
+class ImportMDNData(Tool):
+    """Import features from MDN, or reparse imported features."""
+    logger_name = 'tools.import_mdn'
+    parser_options = ['api', 'user', 'password']
 
+    def run(self, rate=5, *args, **kwargs):
+        self.login()
+        collection = Collection(self.client)
+        collection.load_all('features')
 
-def import_mdn_data(client, rate=5):
-    collection = Collection(client)
-    collection.load_all('features')
+        # Collect feature URIs
+        uris = []
+        for feature in collection.get_resources('features'):
+            if feature.mdn_uri and feature.mdn_uri.get('en'):
+                uris.append((feature.mdn_uri['en'], feature.id.id))
+        total = len(uris)
+        self.logger.info('Features loaded, %d MDN pages found.', total)
 
-    # Collect feature URIs
-    uris = []
-    for feature in collection.get_resources('features'):
-        if feature.mdn_uri and feature.mdn_uri.get('en'):
-            uris.append((feature.mdn_uri['en'], feature.id.id))
-    total = len(uris)
-    logger.info('Features loaded, %d MDN pages found.', total)
+        # Import from MDN, with rate limiting
+        start_time = time.time()
+        mdn_requests = 0
+        counts = {'new': 0, 'reset': 0, 'reparsed': 0, 'unchanged': 0}
+        importer_search = self.api + '/importer/search'
+        log_at = 15
+        logged_at = time.time()
+        for uri, f_id in uris:
+            response = self.client.session.get(
+                importer_search, params={'url': uri})
+            if 'importer/create?' in response.url:
+                self.logger.info('Fetching %s...', uri)
+                counts['new'] += 1
+                create_url = response.url
+                csrf = self.client.session.cookies['csrftoken']
+                params = {
+                    'url': uri,
+                    'feature': f_id,
+                    'csrfmiddlewaretoken': csrf,
+                }
+                response = self.client.session.post(create_url, params)
+                mdn_requests += 1
+            else:
+                response.raise_for_status()
+                obj_url = response.url
+                assert '/importer/' in obj_url
+                reparse_url = obj_url + '/reparse'
+                csrf = self.client.session.cookies['csrftoken']
+                params = {'csrfmiddlewaretoken': csrf}
+                response = self.client.session.post(reparse_url, params)
+                counts['reparsed'] += 1
 
-    # Import from MDN, with rate limiting
-    start_time = time.time()
-    mdn_requests = 0
-    counts = {'new': 0, 'reset': 0, 'reparsed': 0, 'unchanged': 0}
-    importer_search = client.base_url + '/importer/search'
-    log_at = 15
-    logged_at = time.time()
-    for uri, f_id in uris:
-        response = client.session.get(importer_search, params={'url': uri})
-        if 'importer/create?' in response.url:
-            logger.info('Fetching %s...', uri)
-            counts['new'] += 1
-            create_url = response.url
-            csrf = client.session.cookies['csrftoken']
-            params = {
-                'url': uri,
-                'feature': f_id,
-                'csrfmiddlewaretoken': csrf,
-            }
-            response = client.session.post(create_url, params)
-            mdn_requests += 1
-        else:
-            response.raise_for_status()
-            obj_url = response.url
-            assert '/importer/' in obj_url
-            reparse_url = obj_url + '/reparse'
-            csrf = client.session.cookies['csrftoken']
-            params = {'csrfmiddlewaretoken': csrf}
-            response = client.session.post(reparse_url, params)
-            counts['reparsed'] += 1
+            # Pause for rate limiting?
+            current_time = time.time()
+            if rate:
+                elapsed = current_time - start_time
+                target = start_time + float(mdn_requests) / rate
+                current_rate = float(mdn_requests) / elapsed
+                if time.time < target:
+                    rest = int(target - current_time) + 1
+                    self.logger.warning(
+                        "%d pages fetched, %0.2f per second, target rate %d"
+                        " per second.  Resting %d seconds.",
+                        mdn_requests, current_rate, rate, rest)
+                    time.sleep(rest)
+                    logged_at = time.time()
+                    current_time = time.time()
 
-        # Pause for rate limiting?
-        current_time = time.time()
-        if rate:
-            elapsed = current_time - start_time
-            target = start_time + float(mdn_requests) / rate
-            current_rate = float(mdn_requests) / elapsed
-            if time.time < target:
-                rest = int(target - current_time) + 1
-                logger.warning(
-                    "%d pages fetched, %0.2f per second, target rate %d per"
-                    " second.  Resting %d seconds.",
-                    mdn_requests, current_rate, rate, rest)
-                time.sleep(rest)
-                logged_at = time.time()
-                current_time = time.time()
+            # Log progress?
+            if (logged_at + log_at) < current_time:
+                processed = sum(counts.values())
+                percent = int(100 * (float(processed) / total))
+                self.logger.info(
+                    "  Processed %d of %d MDN pages (%d%%)...",
+                    processed, total, percent)
+                logged_at = current_time
 
-        # Log progress?
-        if (logged_at + log_at) < current_time:
-            processed = sum(counts.values())
-            percent = int(100 * (float(processed) / total))
-            logger.info(
-                "  Processed %d of %d MDN pages (%d%%)...",
-                processed, total, percent)
-            logged_at = current_time
-
-    return counts
+        return counts
 
 
 if __name__ == '__main__':
-    import argparse
-    description = 'Import features from MDN, or reparse imported features.'
-    parser = argparse.ArgumentParser(description=description)
-    parser.add_argument(
-        '-a', '--api',
-        help='Base URL of the API (default: http://localhost:8000)',
-        default="http://localhost:8000")
-    parser.add_argument(
-        '-u', '--user',
-        help='Username on API (default: prompt for username)')
-    parser.add_argument(
-        '-v', '--verbose', action="store_true",
-        help='Print extra debug information')
-    parser.add_argument(
-        '-q', '--quiet', action="store_true",
-        help='Only print warnings')
-    args = parser.parse_args()
-
-    # Setup logging
-    verbose = args.verbose
-    quiet = args.quiet
-    console = logging.StreamHandler(sys.stderr)
-    formatter = logging.Formatter('%(levelname)s - %(message)s')
-    logger_name = 'tools'
-    fmat = '%(levelname)s - %(message)s'
-    if quiet:
-        level = logging.WARNING
-    elif verbose:
-        level = logging.DEBUG
-        logger_name = ''
-        fmat = '%(name)s - %(levelname)s - %(message)s'
-    else:
-        level = logging.INFO
-    formatter = logging.Formatter(fmat)
-    console.setLevel(level)
-    console.setFormatter(formatter)
-    logger = logging.getLogger(logger_name)
-    logger.setLevel(level)
-    logger.addHandler(console)
-
-    # Parse arguments
-    api = args.api
-    if api.endswith('/'):
-        api = api[:-1]
-    logger.info("Loading data into %s" % api)
-
-    # Get credentials
-    user = args.user or input("API username: ")
-    password = getpass.getpass("API password: ")
-
-    # Initialize client
-    client = Client(api)
-    client.login(user, password)
-
-    # Load data
-    counts = import_mdn_data(client)
+    tool = ImportMDNData()
+    tool.init_from_command_line()
+    tool.logger.info("Loading data into {tool.api}".format(tool=tool))
+    counts = tool.run()
 
     if counts:
-        logger.info("Import complete. Counts:")
+        tool.logger.info("Import complete. Counts:")
         c_new = counts.get('new', 0)
         c_reset = counts.get('reset', 0)
         c_reparsed = counts.get('reparsed', 0)
@@ -166,6 +105,6 @@ if __name__ == '__main__':
         if c_unchanged:
             c_text.append("%d unchanged" % c_unchanged)
         if c_text:
-            logger.info(', '.join(c_text))
+            tool.logger.info(', '.join(c_text))
     else:
-        logger.info("No data uploaded.")
+        tool.logger.info("No data uploaded.")

--- a/tools/integration_requests.py
+++ b/tools/integration_requests.py
@@ -476,7 +476,7 @@ if __name__ == '__main__':
         password = args.password
 
     # Load data
-    with open(args.cases, 'r') as cases_file:
+    with open(args.cases, 'r', encoding='utf8') as cases_file:
         cases = json.load(cases_file, object_pairs_hook=OrderedDict)
     runner = CaseRunner(
         cases=cases, api=api, raw_dir=args.raw, mode=mode,

--- a/tools/load_spec_data.py
+++ b/tools/load_spec_data.py
@@ -1,347 +1,185 @@
 #!/usr/bin/env python
-
-from __future__ import print_function
-
-import codecs
-import getpass
-import logging
-import os.path
 import re
-import string
-import sys
 
-import requests
-
-from client import Client
-from resources import Collection, CollectionChangeset, Maturity, Specification
-
-try:
-    input = raw_input  # Get the Py2 raw_input
-except NameError:
-    pass  # We're in Py3
-
-logger = logging.getLogger('tools.load_spec_data')
-my_dir = os.path.dirname(os.path.realpath(__file__))
-data_dir = os.path.realpath(os.path.join(my_dir, '..', 'data'))
-SPEC2_FILENAME = os.path.join(data_dir, 'Spec2.txt')
-SPEC2_URL = 'https://developer.mozilla.org/en-US/docs/Template:Spec2?raw'
-SPECNAME_FILENAME = os.path.join(data_dir, 'SpecName.txt')
-SPECNAME_URL = 'https://developer.mozilla.org/en-US/docs/Template:SpecName?raw'
+from common import Tool
+from resources import Collection, Maturity, Specification
 
 
-def get_template(filename, url):
-    if not os.path.exists(filename):
-        logger.info("Downloading " + filename)
-        r = requests.get(url)
-        with codecs.open(filename, 'wb', 'utf8') as f:
-            f.write(r.text)
-    else:
-        logger.info("Using existing " + filename)
+class LoadSpecData(Tool):
+    """Initialize API with specification data from MDN."""
+    logger_name = 'tools.load_spec_data'
+    parser_options = ['api', 'user', 'password']
 
-    with codecs.open(filename, 'r', 'utf8') as f:
-        template = f.read()
-    return template
+    def run(self, *args, **kwargs):
+        self.login()
+        api_collection = Collection(self.client)
+        local_collection = Collection()
 
+        self.logger.info('Reading existing spec data from API')
+        api_collection.load_all('maturities')
+        api_collection.load_all('specifications')
 
-def load_spec_data(client, specname, spec2, confirm=None):
-    """Load a dictionary of specification data into the API"""
-    api_collection = Collection(client)
-    local_collection = Collection()
+        self.logger.info('Reading spec data from MDN templates')
+        specname = self.specname_template()
+        self.parse_specname(specname, api_collection, local_collection)
+        spec2 = self.spec2_template()
+        self.parse_spec2(spec2, local_collection)
 
-    logger.info('Reading existing spec data from API')
-    load_api_spec_data(api_collection)
-    logger.info('Reading spec data from MDN templates')
-    parse_spec_data(specname, spec2, api_collection, local_collection)
+        # Load API sections into local collection
+        local_collection.override_ids_to_match(api_collection)
+        local_specs = local_collection.get_resources('specifications')
+        for local_spec in local_specs:
+            api_spec = api_collection.get('specifications', local_spec.id.id)
+            if api_spec:
+                local_spec.sections = api_spec.sections.ids
+        return self.sync_changes(api_collection, local_collection)
 
-    # Load API sections into local collection
-    local_collection.override_ids_to_match(api_collection)
-    local_specs = local_collection.get_resources('specifications')
-    for local_spec in local_specs:
-        api_spec = api_collection.get('specifications', local_spec.id.id)
-        if api_spec:
-            local_spec.sections = api_spec.sections.ids
+    def specname_template(self):
+        return self.cached_download(
+            'SpecName.txt',
+            'https://developer.mozilla.org/en-US/docs/Template:SpecName?raw')
 
-    changeset = CollectionChangeset(api_collection, local_collection)
-    delta = changeset.changes
-    if delta['new'] or delta['changed'] or delta['deleted']:
-        logger.info(
-            'Changes detected: %d new, %d changed, %d deleted, %d same.',
-            len(delta['new']), len(delta['changed']), len(delta['deleted']),
-            len(delta['same']))
-        if confirm:
-            confirmed = confirm(client, changeset)
-        else:
-            confirmed = True
-        if not confirmed:
-            return {}
-    else:
-        logger.info('No changes')
-        return {}
+    def spec2_template(self):
+        return self.cached_download(
+            'Spec2.txt',
+            'https://developer.mozilla.org/en-US/docs/Template:Spec2?raw')
 
-    counts = changeset.change_original_collection()
-    return counts
+    def parse_specname(self, specname, api_collection, local_collection):
+        phase = 0
+        mdn_key = None
+        name = None
+        url = None
+        slugs = set([
+            s.slug for s in api_collection.get_resources('specifications')])
+        mdn_key_re = re.compile(r"\s+['\"](.*)['\"]\s*:\s*{")
+        name_re = re.compile(r"\s+name\s*:\s*['\"](.*)['\"],?\s*$")
+        url_re = re.compile(r"\s+url\s*:\s*['\"](.*)['\"],?\s*$")
+        api_specs = api_collection.get_resources_by_data_id('specifications')
 
-
-def load_api_spec_data(api_collection):
-    api_collection.load_all('maturities')
-    api_collection.load_all('specifications')
-
-
-def parse_spec_data(specname, spec2, api_collection, local_collection):
-    parse_specname(specname, api_collection, local_collection)
-    parse_spec2(spec2, local_collection)
-
-
-def parse_specname(specname, api_collection, local_collection):
-    phase = 0
-    mdn_key = None
-    name = None
-    url = None
-    slugs = set([
-        s.slug for s in api_collection.get_resources('specifications')])
-    mdn_key_re = re.compile(r"\s+['\"](.*)['\"]\s*:\s*{")
-    name_re = re.compile(r"\s+name\s*:\s*['\"](.*)['\"],?\s*$")
-    url_re = re.compile(r"\s+url\s*:\s*['\"](.*)['\"],?\s*$")
-    api_specs = api_collection.get_resources_by_data_id('specifications')
-
-    for line in specname.split('\n'):
-        if phase == 0:
-            # Looking for start of specList
-            if line.startswith('var specList = {'):
-                phase = 1
-        elif phase == 1:
-            # Inside specList
-            if line.startswith('}'):
-                phase = 2
-            elif mdn_key_re.match(line):
-                assert mdn_key is None
-                mdn_key = mdn_key_re.match(line).group(1).strip()
-            elif name_re.match(line):
-                assert name is None
-                name = name_re.match(line).group(1).strip()
-            elif url_re.match(line):
-                assert url is None
-                url = url_re.match(line).group(1).strip()
-            elif line.startswith('    }'):
-                assert mdn_key is not None
-                assert name is not None
-                assert url is not None
-                if url.startswith('http'):
-                    api_spec = api_specs.get(('specifications', mdn_key))
-                    if api_spec:
-                        slug = api_spec.slug
+        for line in specname.split('\n'):
+            if phase == 0:
+                # Looking for start of specList
+                if line.startswith('var specList = {'):
+                    phase = 1
+            elif phase == 1:
+                # Inside specList
+                if line.startswith('}'):
+                    phase = 2
+                elif mdn_key_re.match(line):
+                    assert mdn_key is None
+                    mdn_key = mdn_key_re.match(line).group(1).strip()
+                elif name_re.match(line):
+                    assert name is None
+                    name = name_re.match(line).group(1).strip()
+                elif url_re.match(line):
+                    assert url is None
+                    url = url_re.match(line).group(1).strip()
+                elif line.startswith('    }'):
+                    assert mdn_key is not None
+                    assert name is not None
+                    assert url is not None
+                    if url.startswith('http'):
+                        api_spec = api_specs.get(('specifications', mdn_key))
+                        if api_spec:
+                            slug = api_spec.slug
+                        else:
+                            slug = self.unique_slugify(mdn_key, slugs)
+                        spec = Specification(
+                            id="_" + slug, slug=slug, mdn_key=mdn_key,
+                            name={u'en': name}, uri={u'en': url}, sections=[])
+                        local_collection.add(spec)
                     else:
-                        slug = unique_slugify(mdn_key, slugs)
-                    spec = Specification(
-                        id="_" + slug, slug=slug, mdn_key=mdn_key,
-                        name={u'en': name}, uri={u'en': url}, sections=[])
-                    local_collection.add(spec)
+                        self.logger.warning(
+                            'Discarding specification "%s" with url "%s"',
+                            mdn_key, url)
+                    mdn_key = None
+                    name = None
+                    url = None
                 else:
-                    logger.warning(
-                        'Discarding specification "%s" with url "%s"',
-                        mdn_key, url)
-                mdn_key = None
-                name = None
-                url = None
-            else:
-                raise Exception('Unparsed line:', line)
-        elif phase == 2:
-            # Not processing rest of SpecName, including dupe lines
-            pass
-    assert phase == 2, "SpecName didn't match expected format"
+                    raise Exception('Unparsed line:', line)
+            elif phase == 2:
+                # Not processing rest of SpecName, including dupe lines
+                pass
+        assert phase == 2, "SpecName didn't match expected format"
 
+    def parse_spec2(self, spec2, collection):
+        phase = 0
+        key = None
+        name = None
+        status_re = re.compile(r"\s+['\"](.*)['\"]\s+: ['\"](.*)['\"],?\s*$")
+        mat_re = re.compile(r"\s+['\"](.*)['\"]\s*:\s*mdn\.localString\({\s*$")
+        name_re = re.compile(r"\s+['\"](.*)['\"]\s*:\s*['\"](.*)['\"],?\s*$")
+        local_specs = collection.get_resources_by_data_id('specifications')
 
-def parse_spec2(specname, local_collection):
-    phase = 0
-    key = None
-    name = None
-    status_re = re.compile(r"\s+['\"](.*)['\"]\s+: ['\"](.*)['\"],?\s*$")
-    mat_re = re.compile(r"\s+['\"](.*)['\"]\s*:\s*mdn\.localString\({\s*$")
-    name_re = re.compile(r"\s+['\"](.*)['\"]\s*:\s*['\"](.*)['\"],?\s*$")
-    local_specs = local_collection.get_resources_by_data_id('specifications')
-
-    for line in spec2.split('\n'):
-        if phase == 0:
-            # Looking for start of status
-            if line.startswith('var status = {'):
-                phase = 1
-        elif phase == 1:
-            # Inside status
-            if line.startswith('}'):
-                phase = 2
-            elif status_re.match(line):
-                spec_key, maturity_key = status_re.match(line).groups()
-                spec = local_specs.get(('specifications', spec_key))
-                if spec:
-                    spec.maturity = maturity_key
+        for line in spec2.split('\n'):
+            if phase == 0:
+                # Looking for start of status
+                if line.startswith('var status = {'):
+                    phase = 1
+            elif phase == 1:
+                # Inside status
+                if line.startswith('}'):
+                    phase = 2
+                elif status_re.match(line):
+                    spec_key, maturity_key = status_re.match(line).groups()
+                    spec = local_specs.get(('specifications', spec_key))
+                    if spec:
+                        spec.maturity = maturity_key
+                    else:
+                        self.logger.warning(
+                            'Skipping maturity for unknown spec "%s"',
+                            spec_key)
                 else:
-                    logger.warning(
-                        'Skipping maturity for unknown spec "%s"', spec_key)
-            else:
-                raise Exception('Unparsed line:', line)
-        elif phase == 2:
-            # Skiping dupe lines, looking for var label
-            if line.startswith('var label = {'):
-                phase = 3
-        elif phase == 3:
-            if line.startswith('}'):
-                phase = 4
-            elif mat_re.match(line):
-                assert key is None
-                key = mat_re.match(line).group(1).strip()
-                name = {}
-            elif name_re.match(line):
-                assert key is not None
-                assert name is not None
-                lang, trans = name_re.match(line).groups()
-                if lang == 'en-US':
-                    lang = 'en'
-                assert lang not in name
-                text = trans.strip().replace('\\\\', '&#92;')
-                text = text.replace('\\', '').replace('&#92;', '\\')
-                name[lang.strip()] = text
-            elif line.startswith('  })'):
-                assert key is not None
-                assert name
-                specs = local_collection.filter(
-                    'specifications', maturity=key)
-                if specs:
-                    maturity = Maturity(id=key, slug=key, name=name)
-                    local_collection.add(maturity)
-                else:
-                    logger.warning('Skipping unused maturity "%s"', key)
-                key = None
-                name = None
-        elif phase == 4:
-            # Not processing rest of file
-            pass
-    assert phase == 4, "Spec2 didn't match expected format"
+                    raise Exception('Unparsed line:', line)
+            elif phase == 2:
+                # Skiping dupe lines, looking for var label
+                if line.startswith('var label = {'):
+                    phase = 3
+            elif phase == 3:
+                if line.startswith('}'):
+                    phase = 4
+                elif mat_re.match(line):
+                    assert key is None
+                    key = mat_re.match(line).group(1).strip()
+                    name = {}
+                elif name_re.match(line):
+                    assert key is not None
+                    assert name is not None
+                    lang, trans = name_re.match(line).groups()
+                    if lang == 'en-US':
+                        lang = 'en'
+                    assert lang not in name
+                    text = trans.strip().replace('\\\\', '&#92;')
+                    text = text.replace('\\', '').replace('&#92;', '\\')
+                    name[lang.strip()] = text
+                elif line.startswith('  })'):
+                    assert key is not None
+                    assert name
+                    specs = collection.filter('specifications', maturity=key)
+                    if specs:
+                        maturity = Maturity(id=key, slug=key, name=name)
+                        collection.add(maturity)
+                    else:
+                        self.logger.warning(
+                            'Skipping unused maturity "%s"', key)
+                    key = None
+                    name = None
+            elif phase == 4:
+                # Not processing rest of file
+                pass
+        assert phase == 4, "Spec2 didn't match expected format"
 
-    # Remove Specs without maturities
-    immature_specs = local_collection.filter('specifications', maturity=None)
-    for spec in immature_specs:
-        logger.warning('Skipping spec with no maturity "%s"', spec.name['en'])
-        local_collection.remove(spec)
-
-
-def slugify(word, attempt=0):
-    # TODO: replace with mdn.scrape.slugify
-    raw = word.lower().encode('utf-8')
-    out = []
-    acceptable = string.ascii_lowercase + string.digits + '_-'
-    for c in raw:
-        if c in acceptable:
-            out += str(c)
-        else:
-            out += '_'
-    slugged = ''.join(out)
-    while '__' in slugged:
-        slugged = slugged.replace('__', '_')
-    if attempt:
-        suffix = str(attempt)
-    else:
-        suffix = ""
-    return slugged[slice(50 - len(suffix))] + suffix
-
-
-def unique_slugify(word, existing):
-    slug = slugify(word)
-    attempt = 0
-    while slug in existing:
-        attempt += 1
-        slug = slugify(word, attempt)
-    existing.add(slug)
-    return slug
-
-
-def confirm_changes(client, changeset):
-    while True:
-        choice = input("Make these changes? (Y/N/D for details) ")
-        if choice.upper() == 'Y':
-            return True
-        elif choice.upper() == 'N':
-            return False
-        elif choice.upper() == 'D':
-            print(changeset.summarize())
-        else:
-            print("Please type Y or N or D.")
+        # Remove Specs without maturities
+        immature_specs = collection.filter('specifications', maturity=None)
+        for spec in immature_specs:
+            self.logger.warning(
+                'Skipping spec with no maturity "%s"', spec.name['en'])
+            collection.remove(spec)
 
 
 if __name__ == '__main__':
-    import argparse
-    description = 'Initialize with specification data from MDN.'
-    parser = argparse.ArgumentParser(description=description)
-    parser.add_argument(
-        '-a', '--api',
-        help='Base URL of the API (default: http://localhost:8000)',
-        default="http://localhost:8000")
-    parser.add_argument(
-        '-u', '--user',
-        help='Username on API (default: prompt for username)')
-    parser.add_argument(
-        '-v', '--verbose', action="store_true",
-        help='Print extra debug information')
-    parser.add_argument(
-        '-q', '--quiet', action="store_true",
-        help='Only print warnings')
-    args = parser.parse_args()
-
-    # Setup logging
-    verbose = args.verbose
-    quiet = args.quiet
-    console = logging.StreamHandler(sys.stderr)
-    formatter = logging.Formatter('%(levelname)s - %(message)s')
-    logger_name = 'tools'
-    fmat = '%(levelname)s - %(message)s'
-    if quiet:
-        level = logging.WARNING
-    elif verbose:
-        level = logging.DEBUG
-        logger_name = ''
-        fmat = '%(name)s - %(levelname)s - %(message)s'
-    else:
-        level = logging.INFO
-    formatter = logging.Formatter(fmat)
-    console.setLevel(level)
-    console.setFormatter(formatter)
-    logger = logging.getLogger(logger_name)
-    logger.setLevel(level)
-    logger.addHandler(console)
-
-    # Parse arguments
-    api = args.api
-    if api.endswith('/'):
-        api = api[:-1]
-    logger.info("Loading data into %s" % api)
-
-    # Get credentials
-    user = args.user or input("API username: ")
-    password = getpass.getpass("API password: ")
-
-    # Initialize client
-    client = Client(api)
-    client.login(user, password)
-
-    # Load data
-    specname = get_template(SPECNAME_FILENAME, SPECNAME_URL)
-    spec2 = get_template(SPEC2_FILENAME, SPEC2_URL)
-    counts = load_spec_data(client, specname, spec2, confirm_changes)
-
-    if counts:
-        logger.info("Changes complete. Counts:")
-        for resource_type, changes in counts.items():
-            c_new = changes.get('new', 0)
-            c_deleted = changes.get('deleted', 0)
-            c_changed = changes.get('changed', 0)
-            c_text = []
-            if c_new:
-                c_text.append("%d new" % c_new)
-            if c_deleted:
-                c_text.append("%d deleted" % c_deleted)
-            if c_changed:
-                c_text.append("%d changed" % c_changed)
-            if c_text:
-                logger.info("  %s: %s" % (
-                    resource_type.title(), ', '.join(c_text)))
-    else:
-        logger.info("No data uploaded.")
+    tool = LoadSpecData()
+    tool.init_from_command_line()
+    tool.logger.info("Loading data into {tool.api}".format(tool=tool))
+    changes = tool.run()
+    tool.report_changes(changes)

--- a/tools/load_webcompat_data.py
+++ b/tools/load_webcompat_data.py
@@ -1,162 +1,66 @@
 #!/usr/bin/env python
-
-from __future__ import print_function
-
 from cgi import escape
 from collections import defaultdict
-import codecs
-import getpass
-import json
-import logging
-import os.path
+from json import loads
 import re
-import string
-import sys
 
-import requests
-
-from client import Client
-from resources import (
-    Collection, CollectionChangeset, Browser, Version, Feature, Support)
-
-try:
-    input = raw_input  # Get the Py2 raw_input
-except NameError:
-    pass  # We're in Py3
+from common import Tool
+from resources import Collection, Browser, Version, Feature, Support
 
 
-logger = logging.getLogger('tools.load_webcompat_data')
-my_dir = os.path.dirname(os.path.realpath(__file__))
-data_dir = os.path.realpath(os.path.join(my_dir, '..', 'data'))
-COMPAT_DATA_FILENAME = os.path.join(data_dir, "data-human.json")
-COMPAT_DATA_URL = (
-    "https://raw.githubusercontent.com/webplatform/compatibility-data"
-    "/master/data-human.json")
-known_browsers = [
-    "Chrome",
-    "Firefox",
-    "Internet Explorer",
-    "Opera",
-    "Safari",
-    "Android",
-    "Chrome for Android",
-    "Chrome Mobile",
-    "Firefox Mobile",
-    "IE Mobile",
-    "Opera Mini",
-    "Opera Mobile",
-    "Safari Mobile",
-    "BlackBerry",
-    "Firefox OS",
-]
-version_re = re.compile("^[.\d]+$")
+class LoadWebcompatData(Tool):
+    """Initialize with data from the webcompat project."""
+    logger_name = 'tools.load_webcompat_data'
+    parser_options = ['api', 'user', 'password']
 
+    def run(self, *args, **kwargs):
+        self.login()
 
-def get_compat_data(filename, url):
-    if not os.path.exists(filename):
-        logger.info("Downloading " + filename)
-        r = requests.get(url)
-        with codecs.open(filename, 'wb', 'utf8') as f:
-            f.write(r.text)
-    else:
-        logger.info("Using existing " + filename)
+        api_collection = Collection(self.client)
+        local_collection = Collection()
+        compat_data = loads(self.cached_download(
+            "data-human.json",
+            "https://raw.githubusercontent.com/webplatform/compatibility-data"
+            "/master/data-human.json"))
 
-    with codecs.open(filename, 'r', 'utf8') as f:
-        compat_data = json.load(f)
-    return compat_data
+        self.logger.info('Reading existing feature data from API')
+        for resource in ['browsers', 'versions', 'features', 'supports']:
+            api_collection.load_all(resource)
+        self.logger.info('Loading feature data from webplatform repository')
+        self.parse_compat_data(compat_data, local_collection)
 
+        if not self.all_data:
+            self.logger.info('Selecting subset of data')
+            self.select_subset(local_collection)
 
-def load_compat_data(client, compat_data, all_data=False, confirm=None):
-    """Load a dictionary of compatibility data into the API"""
-    api_collection = Collection(client)
-    local_collection = Collection()
+        return self.sync_changes(api_collection, local_collection)
 
-    logger.info('Reading existing feature data from API')
-    load_api_feature_data(api_collection)
-    logger.info('Loading feature data from webplatform repository')
-    parse_compat_data(compat_data, local_collection)
+    def get_parser(self):
+        parser = super(LoadWebcompatData, self).get_parser()
+        parser.add_argument(
+            '--all-data', action="store_true",
+            help='Import all the data, rather than a subset')
+        return parser
 
-    if not all_data:
-        logger.info('Selecting subset of data')
-        select_subset(local_collection)
+    def parse_compat_data(self, compat_data, local_collection):
+        local_collection.feature_slugs = set()
+        for key, value in compat_data['data'].items():
+            self.parse_compat_data_item(key, value, local_collection)
 
-    logger.info('Looking for changes...')
-    changeset = CollectionChangeset(api_collection, local_collection)
-    delta = changeset.changes
+        # Populate the sorted versions
+        browser_versions = defaultdict(list)
+        for version in local_collection.get_resources_by_data_id(
+                'versions').values():
+            browser_versions[version.browser.id].append(version)
+        for browser_id, versions in browser_versions.items():
+            browser = local_collection.get('browsers', browser_id)
+            browser.versions = sorted([v.id.id for v in versions])
 
-    if delta['new'] or delta['changed'] or delta['deleted']:
-        logger.info(
-            'Changes detected: %d new, %d changed, %d deleted, %d same.',
-            len(delta['new']), len(delta['changed']), len(delta['deleted']),
-            len(delta['same']))
-        if confirm:
-            confirmed = confirm(client, changeset)
-        else:
-            confirmed = True
-        if not confirmed:
-            return {}
-    else:
-        logger.info('No changes')
-        return {}
-
-    counts = changeset.change_original_collection()
-    return counts
-
-
-def load_api_feature_data(api_collection):
-    api_collection.load_all('browsers')
-    api_collection.load_all('versions')
-    api_collection.load_all('features')
-    api_collection.load_all('supports')
-
-
-def parse_compat_data(compat_data, local_collection):
-    local_collection.feature_slugs = set()
-    for key, value in compat_data['data'].items():
-        parse_compat_data_item(key, value, local_collection)
-
-    # Populate the sorted versions
-    browser_versions = defaultdict(list)
-    for version in local_collection.get_resources_by_data_id(
-            'versions').values():
-        browser_versions[version.browser.id].append(version)
-    for browser_id, versions in browser_versions.items():
-        browser = local_collection.get('browsers', browser_id)
-        browser.versions = sorted([v.id.id for v in versions])
-
-
-def slugify(word, attempt=0):
-    # TODO: replace with mdn.scrape.slugify
-    raw = word.lower().encode('utf-8')
-    out = []
-    acceptable = string.ascii_lowercase + string.digits + '_-'
-    for c in raw:
-        if c in acceptable:
-            out += str(c)
-        else:
-            out += '_'
-    slugged = ''.join(out)
-    while '__' in slugged:
-        slugged = slugged.replace('__', '_')
-    if attempt:
-        suffix = str(attempt)
-    else:
-        suffix = ""
-    with_suffix = slugged[slice(50 - len(suffix))] + suffix
-    return with_suffix.decode('utf-8')
-
-
-def unique_slugify(word, existing):
-    slug = slugify(word)
-    attempt = 0
-    while slug in existing:
-        attempt += 1
-        slug = slugify(word, attempt)
-    existing.add(slug)
-    return slug
-
-
-def parse_compat_data_item(key, item, local_collection):
+    known_browsers = [
+        "Chrome", "Firefox", "Internet Explorer", "Opera", "Safari", "Android",
+        "Chrome for Android", "Chrome Mobile", "Firefox Mobile", "IE Mobile",
+        "Opera Mini", "Opera Mobile", "Safari Mobile", "BlackBerry",
+        "Firefox OS"]
     browser_conversions = {
         "IE Phone": "IE Mobile",
         "Chrome for Andriod": "Chrome for Android",
@@ -170,9 +74,7 @@ def parse_compat_data_item(key, item, local_collection):
         "Windows Phone": "IE Mobile",
         "iOS Safari": "Safari Mobile",
     }
-    version_ignore = [
-        'notes',
-    ]
+    version_ignore = ['notes']
     support_map = {
         'y': u'yes',
         'u': u'unknown',
@@ -196,240 +98,156 @@ def parse_compat_data_item(key, item, local_collection):
         'Internet Explorer': u'-ms',
     }
 
-    if "breadcrumb" in item:
-        assert "contents" in item
-        assert "jsonselect" in item
-        assert "links" in item
+    def parse_compat_data_item(self, key, item, collection):
+        if "breadcrumb" in item:
+            assert "contents" in item
+            assert "jsonselect" in item
+            assert "links" in item
 
-        # Feature heirarchy
-        url = item['links'][0]["url"]
-        assert url.startswith('https://developer.mozilla.org/en-US/docs/')
-        mdn_subpath = url.split('en-US/docs/', 1)[1]
-        path_bits = mdn_subpath.split('/')
-        feature_id = ()
-        for bit in path_bits:
-            last_feature_id = feature_id
-            feature_id += (bit,)
-            if not local_collection.get('features', feature_id):
-                slug = unique_slugify(
-                    '-'.join(feature_id), local_collection.feature_slugs)
-                local_collection.add(Feature(
-                    id=feature_id, slug=slug, name={u'en': bit},
-                    experimental=False, obsolete=False, stable=True,
-                    standardized=True, mdn_uri=None,
-                    parent=last_feature_id or None))
-        parent_feature_id = feature_id
-        parent_feature = local_collection.get('features', parent_feature_id)
-        parent_feature.mdn_uri = {u'en': url}
-
-        for env, rows in item['contents'].items():
-            assert env in ('desktop', 'mobile')
-            for feature, columns in rows.items():
-                # Add feature
-                feature_id = parent_feature_id + (feature,)
-                if not local_collection.get('features', feature_id):
-                    slug = unique_slugify(
-                        '-'.join(feature_id), local_collection.feature_slugs)
-                    local_collection.add(Feature(
-                        id=feature_id, slug=slug,
-                        mdn_uri={u'en': url}, name={u'en': escape(feature)},
+            # Feature heirarchy
+            url = item['links'][0]["url"]
+            assert url.startswith('https://developer.mozilla.org/en-US/docs/')
+            mdn_subpath = url.split('en-US/docs/', 1)[1]
+            path_bits = mdn_subpath.split('/')
+            feature_id = ()
+            for bit in path_bits:
+                last_feature_id = feature_id
+                feature_id += (bit,)
+                if not collection.get('features', feature_id):
+                    slug = self.unique_slugify(
+                        '-'.join(feature_id), collection.feature_slugs)
+                    collection.add(Feature(
+                        id=feature_id, slug=slug, name={u'en': bit},
                         experimental=False, obsolete=False, stable=True,
-                        standardized=True, parent=parent_feature_id))
+                        standardized=True, mdn_uri=None,
+                        parent=last_feature_id or None))
+            parent_feature_id = feature_id
+            parent_feature = collection.get(
+                'features', parent_feature_id)
+            parent_feature.mdn_uri = {u'en': url}
 
-                # Add browser
-                for raw_browser, versions in columns.items():
-                    browser = browser_conversions.get(raw_browser, raw_browser)
-                    assert browser in known_browsers, raw_browser
-                    browser_id = known_browsers.index(browser)
-                    if not local_collection.get('browsers', browser_id):
-                        local_collection.add(Browser(
-                            id=browser_id, slug=slugify(browser),
-                            name={u'en': browser}, note=None))
+            for env, rows in item['contents'].items():
+                assert env in ('desktop', 'mobile')
+                for feature, columns in rows.items():
+                    # Add feature
+                    feature_id = parent_feature_id + (feature,)
+                    if not collection.get('features', feature_id):
+                        slug = self.unique_slugify(
+                            '-'.join(feature_id),
+                            collection.feature_slugs)
+                        collection.add(Feature(
+                            id=feature_id, slug=slug,
+                            mdn_uri={u'en': url},
+                            name={u'en': escape(feature)},
+                            experimental=False, obsolete=False, stable=True,
+                            standardized=True, parent=parent_feature_id))
 
-                    version_note = versions.get('notes', {})
-                    for raw_version, raw_support in versions.items():
-                        # Add version
-                        if raw_version in version_ignore:
-                            continue
-                        version, version_id = convert_version(
-                            browser_id, raw_version)
-                        if not local_collection.get('versions', version_id):
-                            local_collection.add(Version(
-                                id=version_id, version=version,
-                                browser=browser_id, note=None,
-                                release_day=None, release_notes_uri=None,
-                                retirement_day=None, status=u'unknown'))
+                    # Add browser
+                    for raw_browser, versions in columns.items():
+                        browser = self.browser_conversions.get(
+                            raw_browser, raw_browser)
+                        assert browser in self.known_browsers, raw_browser
+                        browser_id = self.known_browsers.index(browser)
+                        if not collection.get('browsers', browser_id):
+                            collection.add(Browser(
+                                id=browser_id, slug=self.slugify(browser),
+                                name={u'en': browser}, note=None))
 
-                        # Add support
-                        support_id = (version_id, feature_id)
-                        if not local_collection.get('supports', support_id):
-                            notes = []
-                            obj = Support(
-                                id=support_id, feature=feature_id,
-                                version=version_id, alternate_name=None,
-                                alternate_mandatory=False,
-                                default_config=None,
-                                note=None, prefix=None, prefix_mandatory=False,
-                                protected=False, requires_config=None)
-                            obj.support = support_map[raw_support[0]]
-                            if obj.support == 'prefix':
-                                obj.support = 'yes'
-                                obj.prefix = support_prefix[browser]
+                        version_note = versions.get('notes', {})
+                        for raw_version, raw_support in versions.items():
+                            # Add version
+                            if raw_version in self.version_ignore:
+                                continue
+                            version, version_id = self.convert_version(
+                                browser_id, raw_version)
+                            if not collection.get('versions', version_id):
+                                collection.add(Version(
+                                    id=version_id, version=version,
+                                    browser=browser_id, note=None,
+                                    release_day=None, release_notes_uri=None,
+                                    retirement_day=None, status=u'unknown'))
 
-                            if len(raw_support) > 1:
-                                notes.append(
-                                    'Original support string is "%s"'
-                                    % escape(raw_support))
-                            for item in version_note.items():
-                                notes.append('%s: %s' % item)
+                            # Add support
+                            support_id = (version_id, feature_id)
+                            if not collection.get('supports', support_id):
+                                notes = []
+                                obj = Support(
+                                    id=support_id, feature=feature_id,
+                                    version=version_id, alternate_name=None,
+                                    alternate_mandatory=False,
+                                    default_config=None, note=None,
+                                    prefix=None, prefix_mandatory=False,
+                                    protected=False, requires_config=None)
+                                obj.support = self.support_map[raw_support[0]]
+                                if obj.support == 'prefix':
+                                    obj.support = 'yes'
+                                    obj.prefix = self.support_prefix[browser]
 
-                            if notes:
-                                joined = '<br>'.join(escape(n) for n in notes)
-                                obj.note = {'en': joined}
-                            if obj.prefix:
-                                obj.prefix_mandatory = True
-                            local_collection.add(obj)
-    else:
-        for subkey, subitem in item.items():
-            parse_compat_data_item(subkey, subitem, local_collection)
+                                if len(raw_support) > 1:
+                                    notes.append(
+                                        'Original support string is "%s"'
+                                        % escape(raw_support))
+                                for item in version_note.items():
+                                    notes.append('%s: %s' % item)
 
-
-def convert_version(browser_id, raw_version):
-    if raw_version == '?':
-        version = None
-    else:
-        version = raw_version
-    if not version:
-        version = None
-        version_id = (browser_id,)
-    else:
-        assert version_re.match(version), raw_version
-        bits = tuple(int(x) for x in version.split('.'))
-        if len(bits) == 1:
-            # Prefer 12.0 format to 12 format
-            version += '.0'
-            bits += (0,)
-        version_id = (browser_id,) + bits
-    return version, version_id
-
-
-def select_subset(local_collection):
-    """Discard all but a subset of features and supports"""
-    # Select features to keep
-    keep_feature_ids = set()
-    for feature in local_collection.get_resources('features'):
-        if feature.mdn_uri and 'Web/CSS/c' in feature.mdn_uri['en']:
-            keep_feature_ids.add(feature.id.id)
-            parent = feature.parent.get()
-            while parent:
-                keep_feature_ids.add(parent.id.id)
-                parent = parent.parent.get()
-
-    # Discard unrelated supports
-    for support in local_collection.get_resources('supports')[:]:
-        if support.feature.id not in keep_feature_ids:
-            local_collection.remove(support)
-
-    # Discard unrelated features
-    for feature in local_collection.get_resources('features')[:]:
-        if feature.id.id not in keep_feature_ids:
-            local_collection.remove(feature)
-
-
-def confirm_changes(client, changeset):
-    while True:
-        choice = input("Make these changes? (Y/N/D for details) ")
-        if choice.upper() == 'Y':
-            return True
-        elif choice.upper() == 'N':
-            return False
-        elif choice.upper() == 'D':
-            print(changeset.summarize())
+                                if notes:
+                                    joined = '<br>'.join(
+                                        escape(n) for n in notes)
+                                    obj.note = {'en': joined}
+                                if obj.prefix:
+                                    obj.prefix_mandatory = True
+                                collection.add(obj)
         else:
-            print("Please type Y or N or D.")
+            for subkey, subitem in item.items():
+                self.parse_compat_data_item(subkey, subitem, collection)
+
+    version_re = re.compile("^[.\d]+$")
+
+    def convert_version(self, browser_id, raw_version):
+        if raw_version == '?':
+            version = None
+        else:
+            version = raw_version
+        if not version:
+            version = None
+            version_id = (browser_id,)
+        else:
+            assert self.version_re.match(version), raw_version
+            bits = tuple(int(x) for x in version.split('.'))
+            if len(bits) == 1:
+                # Prefer 12.0 format to 12 format
+                version += '.0'
+                bits += (0,)
+            version_id = (browser_id,) + bits
+        return version, version_id
+
+    def select_subset(self, collection):
+        """Discard all but a subset of features and supports"""
+        # Select features to keep
+        keep_feature_ids = set()
+        for feature in collection.get_resources('features'):
+            if feature.mdn_uri and 'Web/CSS/c' in feature.mdn_uri['en']:
+                keep_feature_ids.add(feature.id.id)
+                parent = feature.parent.get()
+                while parent:
+                    keep_feature_ids.add(parent.id.id)
+                    parent = parent.parent.get()
+
+        # Discard unrelated supports
+        for support in collection.get_resources('supports')[:]:
+            if support.feature.id not in keep_feature_ids:
+                collection.remove(support)
+
+        # Discard unrelated features
+        for feature in collection.get_resources('features')[:]:
+            if feature.id.id not in keep_feature_ids:
+                collection.remove(feature)
 
 
 if __name__ == '__main__':
-    import argparse
-    description = 'Initialize with compatibility data from webcompat project.'
-    parser = argparse.ArgumentParser(description=description)
-    parser.add_argument(
-        '-a', '--api',
-        help='Base URL of the API (default: http://localhost:8000)',
-        default="http://localhost:8000")
-    parser.add_argument(
-        '-u', '--user',
-        help='Username on API (default: prompt for username)')
-    parser.add_argument(
-        '-v', '--verbose', action="store_true",
-        help='Print extra debug information')
-    parser.add_argument(
-        '-q', '--quiet', action="store_true",
-        help='Only print warnings')
-    parser.add_argument(
-        '--all-data', action="store_true",
-        help='Import all the data, rather than a subset')
-    args = parser.parse_args()
-
-    # Setup logging
-    verbose = args.verbose
-    quiet = args.quiet
-    console = logging.StreamHandler(sys.stderr)
-    formatter = logging.Formatter('%(levelname)s - %(message)s')
-    logger_name = 'tools'
-    fmat = '%(levelname)s - %(message)s'
-    if quiet:
-        level = logging.WARNING
-    elif verbose:
-        level = logging.DEBUG
-        logger_name = ''
-        fmat = '%(name)s - %(levelname)s - %(message)s'
-    else:
-        level = logging.INFO
-    formatter = logging.Formatter(fmat)
-    console.setLevel(level)
-    console.setFormatter(formatter)
-    logger = logging.getLogger(logger_name)
-    logger.setLevel(level)
-    logger.addHandler(console)
-
-    # Parse arguments
-    api = args.api
-    if api.endswith('/'):
-        api = api[:-1]
-    all_data = args.all_data
-    logger.info(
-        "Loading %s data into %s",
-        'all' if all_data else 'subset of', api)
-
-    # Get credentials
-    user = args.user or input("API username: ")
-    password = getpass.getpass("API password: ")
-
-    # Initialize client
-    client = Client(api)
-    client.login(user, password)
-
-    # Load data
-    compat_data = get_compat_data(COMPAT_DATA_FILENAME, COMPAT_DATA_URL)
-    counts = load_compat_data(
-        client, compat_data, all_data=all_data, confirm=confirm_changes)
-
-    if counts:
-        logger.info("Changes complete. Counts:")
-        for resource_type, changes in counts.items():
-            c_new = changes.get('new', 0)
-            c_deleted = changes.get('deleted', 0)
-            c_changed = changes.get('changed', 0)
-            c_text = []
-            if c_new:
-                c_text.append("%d new" % c_new)
-            if c_deleted:
-                c_text.append("%d deleted" % c_deleted)
-            if c_changed:
-                c_text.append("%d changed" % c_changed)
-            if c_text:
-                logger.info("  %s: %s" % (
-                    resource_type.title(), ', '.join(c_text)))
-    else:
-        logger.info("No data uploaded.")
+    tool = LoadWebcompatData()
+    tool.init_from_command_line()
+    how_much = 'all' if tool.all_data else 'subset of'
+    tool.logger.info("Loading {} data into {}".format(how_much, tool.api))
+    changes = tool.run()
+    tool.report_changes(changes)

--- a/tools/load_webcompat_data.py
+++ b/tools/load_webcompat_data.py
@@ -67,7 +67,7 @@ def get_compat_data(filename, url):
 
 
 def load_compat_data(client, compat_data, all_data=False, confirm=None):
-    """Load a dictionary of compatiblity data into the API"""
+    """Load a dictionary of compatibility data into the API"""
     api_collection = Collection(client)
     local_collection = Collection()
 

--- a/tools/mirror_mdn_features.py
+++ b/tools/mirror_mdn_features.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python
+
+from __future__ import print_function
+
+from cgi import escape
+from json import loads
+from string import lowercase
+import time
+
+from common import Tool
+from resources import Collection, Feature
+
+
+class MirrorMDNFeatures(Tool):
+    """Create and Update API features for MDN pages."""
+    logger_name = 'tools.mirror_mdn_features'
+    parser_options = ['api', 'user', 'password', 'data']
+    base_mdn_domain = 'https://developer.mozilla.org'
+    base_mdn_uri = base_mdn_domain + '/en-US/docs/'
+    rate = 5
+
+    def __init__(self, *args, **kwargs):
+        super(MirrorMDNFeatures, self).__init__(*args, **kwargs)
+        self.rate_limit_start = time.time()
+        self.rate_limit_requests = 0
+
+    def run(self, *args, **kwargs):
+        self.login()
+        api_collection = Collection(self.client)
+        self.logger.info('Reading existing features from API')
+        api_collection.load_all('features')
+
+        # Copy feature to working local collection
+        local_collection = Collection()
+        local_collection.load_collection(api_collection)
+        features = self.known_features(local_collection)
+        feature_by_uri = dict((k[0], k[2]) for k in features)
+        feature_by_slug = dict((k[1], k[2]) for k in features)
+        slugs = set(feature_by_slug.keys())
+
+        self.logger.info('Reading pages from MDN')
+        mdn_uris = self.current_mdn_uris()
+
+        new_page, needs_url, existing_page = 0, 0, 0
+        for path, parent_path, raw_slug, title in mdn_uris:
+            uri = self.base_mdn_domain + path
+            feature = feature_by_uri.get(uri)
+            if feature:
+                existing_page += 1
+                feature.name = self.to_trans(title)
+            else:
+                slug = self.unique_slugify(raw_slug, slugs)
+                feature = feature_by_slug.get(slug)
+                if feature:
+                    # Need to add URI to feature
+                    feature.mdn_uri = {'en': uri}
+                    feature_by_uri[uri] = feature
+                    needs_url += 1
+                else:
+                    if parent_path:
+                        parent_uri = self.base_mdn_domain + parent_path
+                        parent_feature = feature_by_uri.get(parent_uri)
+                        assert parent_feature,\
+                            'No feature for parent page {}'.format(parent_uri)
+                        parent_id = parent_feature.id.id
+                    else:
+                        parent_id = None
+                    feature = Feature(
+                        id='_' + slug, slug=slug, mdn_uri={'en': uri},
+                        name=self.to_trans(title), parent=parent_id)
+                    local_collection.add(feature)
+                    feature_by_uri[uri] = feature
+                    feature_by_slug[slug] = feature
+        self.logger.info(
+            'MDN URIs gathered, %d found (%d new, %d needs url, %d existing).',
+            len(mdn_uris), new_page, needs_url, existing_page)
+
+        return self.sync_changes(api_collection, local_collection)
+
+    def to_trans(self, text):
+        """Convert text to an API translatable string.
+
+        If it looks canonical, convert to display in a <code></code> tag.
+        If it looks like English, convert to display in <div></div> tag.
+        """
+        if ' ' in text:
+            canonical = False
+        elif text[0] in lowercase:
+            canonical = True
+        elif text[0] == '<' and text[-1] == ">":
+            canonical = True
+        elif text[0] == ':':
+            canonical = True
+        elif text[0].endswith("()"):
+            canonical = True
+        else:
+            canonical = False
+        if canonical:
+            return escape(text)
+        else:
+            return {'en': escape(text)}
+
+    def current_mdn_uris(self):
+        """Load potential URIs from MDN."""
+        base_paths = [
+            'Web', 'Navigation_timing', 'Server-sent_events', 'WebAPI',
+            'WebSockets']
+        headers = {'Accept': 'application/json'}
+
+        data = []
+        for base_path in base_paths:
+            cache_file = base_path + "_mdn_children.json"
+            mdn_uri = self.base_mdn_uri + base_path + '$children'
+            children = self.cached_download(
+                cache_file, mdn_uri, headers=headers, retries=60)
+            data.extend(self.gather_mdn_json(loads(children)))
+        return data
+
+    def known_features(self, collection):
+        """Load URIs from collection's features."""
+        uris = []
+        for feature in collection.get_resources('features'):
+            uri = feature.mdn_uri and feature.mdn_uri.get('en')
+            slug = feature.slug
+            uris.append((uri, slug, feature))
+        return uris
+
+    def gather_mdn_json(self, mdn_json, parent_path=None):
+        """Recursively gather data from MDN JSON."""
+        path = mdn_json['url']
+        title = mdn_json['title']
+        slug = mdn_json['slug']
+        subpages = mdn_json['subpages']
+        data = [(path, parent_path, slug, title)]
+        for subjson in subpages:
+            data.extend(self.gather_mdn_json(subjson, path))
+        return data
+
+    def rate_limit(self):
+        """Pause and return True if exceeding the rate limit."""
+        self.rate_limit_requests += 1
+
+        # Sleep if we need to wait for the rate limit
+        current_time = time.time()
+        if self.rate:
+            elapsed = current_time - self.rate_limit_start
+            target = (
+                self.rate_limit_start +
+                float(self.rate_limit_requests) / self.rate)
+            current_rate = float(self.rate_limit_requests) / elapsed
+            if current_time < target:
+                rest = int(target - current_time) + 1
+                self.logger.warning(
+                    "%d pages fetched, %0.2f per second, target rate %d per"
+                    " second.  Resting %d seconds.",
+                    self.rate_limit_requests, current_rate, self.rate, rest)
+                time.sleep(rest)
+                return True
+        return False
+
+
+if __name__ == '__main__':
+    tool = MirrorMDNFeatures()
+    tool.init_from_command_line()
+    tool.logger.info("Loading data into {tool.api}...".format(tool=tool))
+    changes = tool.run()
+    tool.report_changes(changes)

--- a/tools/resources.py
+++ b/tools/resources.py
@@ -339,13 +339,13 @@ class Section(Resource):
         'history': ('historical_sections', True),
         'history_current': ('historical_sections', False),
     }
-    _id_data = ('number_en', 'specification.mdn_key')
+    _id_data = ('specification.mdn_key', 'subpath_en')
 
     @property
-    def number_en(self):
-        if self.number is None:
+    def subpath_en(self):
+        if self.subpath is None:
             return None
-        return self.number.get('en', None)
+        return self.subpath.get('en', None)
 
 
 class Maturity(Resource):

--- a/tools/resources.py
+++ b/tools/resources.py
@@ -104,7 +104,7 @@ class Resource(object):
         self._collection = collection
 
         assert hasattr(self, '_resource_type'), "Must set _resource_type"
-        assert hasattr(self, '_id_data'), "Must set _unique index"
+        assert hasattr(self, '_id_data'), "Must set _id_data"
         assert tuple(sorted(self._id_data)) == tuple(self._id_data), \
             "_id_data must be sorted"
 
@@ -682,9 +682,8 @@ class CollectionChangeset(object):
 
         # Summarize new resources
         for item in self.changes['new'].values():
-            resource_type = item._resource_type
             rep = self.format_item(item)
-            out.append("New %s:\n%s" % (resource_type, rep))
+            out.append("New:\n%s" % rep)
 
         # Summarize deleted resources
         for item in self.changes['deleted'].values():

--- a/tools/resources.py
+++ b/tools/resources.py
@@ -462,6 +462,23 @@ class Collection(object):
         done_count = len(self._repository.get(resource_type, []))
         return done_count - original_count
 
+    def load_collection(self, from_collection):
+        """Load data from another collection.
+
+        This is useful for loading an original collection, altering the
+        resources, and then syncing the changes back to the original
+        collection.
+        """
+        assert not self.client, "Don't set client when using load_collection."
+        assert not self._repository, "Can't load with existing resources"
+        for data_id, resource in from_collection.get_all_by_data_id().items():
+            json_api = resource.to_json_api()
+            if resource.id:
+                json_api[resource._resource_type]['id'] = resource.id.id
+            new_resource = type(resource)()
+            new_resource.from_json_api(json_api)
+            self.add(new_resource)
+
     def override_ids_to_match(self, sync_collection):
         """Change IDs to match another collection."""
         self._override_ids = {}

--- a/tools/resources.py
+++ b/tools/resources.py
@@ -222,7 +222,18 @@ class Resource(object):
         data = OrderedDict()
         for field in self._writeable_property_fields:
             if field in self._data:
-                data[field] = self._data[field]
+                raw_value = self._data[field]
+                if hasattr(raw_value, 'keys') and 'en' in raw_value:
+                    # Sort languages
+                    value = OrderedDict()
+                    value['en'] = raw_value['en']
+                    for lang in sorted(raw_value.keys()):
+                        if lang != 'en':
+                            value[lang] = raw_value[lang]
+                else:
+                    value = raw_value
+
+                data[field] = value
         for field, attr in self._writeable_link_fields.items():
             is_sorted = attr[1] == Resource.SORTED
             if not with_sorted and is_sorted:

--- a/tools/sample_mdn.py
+++ b/tools/sample_mdn.py
@@ -1,50 +1,57 @@
 #!/usr/bin/env python
-
 from __future__ import print_function
+
 import re
-import os.path
 import random
-import urllib
 import webbrowser
 
+from common import Tool
+
+try:
+    input = raw_input  # Py2?
+except NameError:
+    pass  # Nope Py3
+
 re_url = re.compile(r'\s*"url":\s"([^"]*)"')
-count = 0
 
-print("Go through data-human.json, and open each in the browser")
 
-# Fetch the file from github
-filename = "data-human.json"
-if not os.path.exists(filename):
-    print("Downloading data-human.json")
-    url = (
-        "https://raw.githubusercontent.com/webplatform/compatibility-data"
-        "/master/data-human.json")
-    urllib.urlretrieve(url, filename)
+class SampleMDN(Tool):
+    """Open a random MDN URL scraped from the webcompat project."""
+    logger_name = 'tools.sample_mdn'
 
-# Extract the URLs
-urls = []
-with open(filename, 'r') as f:
-    for raw_line in f:
-        line = raw_line.strip()
-        match = re_url.match(line)
-        if match:
-            url = match.group(1)
-            urls.append(url)
+    def run(self, *args, **kwargs):
+        count = 0
+        urls = self.get_urls()
+        while True:
+            url = random.choice(urls)
+            self.logger.info("%d: %s", count, url)
+            count += 1
+            webbrowser.open(url + '#Specifications')
+            x = input("Enter to continue, or q+Enter to quit: ")
 
-# Open them
-count = 0
-while True:
-    print("%d: %s" % (count, url))
-    count += 1
-    url = random.choice(urls)
-    webbrowser.open(url + '#Specifications')
-    try:
-        input = raw_input  # Py2?
-    except NameError:
-        pass  # Nope Py3
-    x = input("Enter to continue, or q+Enter to quit: ")
+            if x == 'q':
+                break
 
-    if x == 'q':
-        break
+        self.logger.info("%d URLs visited" % count)
+        return count
 
-print("%d URLs visited" % count)
+    def get_urls(self):
+        data_human = self.cached_download(
+            'data-human.json',
+            "https://raw.githubusercontent.com/webplatform/compatibility-data"
+            "/master/data-human.json")
+
+        urls = []
+        for raw_line in data_human.split('\n'):
+            line = raw_line.strip()
+            match = re_url.match(line)
+            if match:
+                url = match.group(1)
+                urls.append(url)
+        return urls
+
+
+if __name__ == '__main__':
+    tool = SampleMDN()
+    tool.init_from_command_line()
+    tool.run()

--- a/tools/tests/test_resources.py
+++ b/tools/tests/test_resources.py
@@ -745,6 +745,34 @@ class TestCollection(TestCase):
         self.col.remove(firefox)
         self.assertEqual([], self.col.get_resources('browsers'))
 
+    def test_load_collection(self):
+        firefox = Browser(slug='firefox')
+        self.col.add(firefox)
+        key = ('browsers', 'firefox')
+        self.assertEqual(
+            {key: firefox}, self.col.get_resources_by_data_id('browsers'))
+        copy_col = Collection()
+        copy_col.load_collection(self.col)
+        new_resources = copy_col.get_resources_by_data_id('browsers')
+        self.assertEqual([key], list(new_resources.keys()))
+        new_firefox = new_resources[key]
+        self.assertEqual(firefox.to_json_api(), new_firefox.to_json_api())
+        self.assertIsNone(firefox.id)
+
+    def test_load_collection_with_id(self):
+        firefox = Browser(slug='firefox', id=6)
+        self.col.add(firefox)
+        key = ('browsers', 'firefox')
+        self.assertEqual(
+            {key: firefox}, self.col.get_resources_by_data_id('browsers'))
+        copy_col = Collection()
+        copy_col.load_collection(self.col)
+        new_resources = copy_col.get_resources_by_data_id('browsers')
+        self.assertEqual([key], list(new_resources.keys()))
+        new_firefox = new_resources[key]
+        self.assertEqual(firefox.to_json_api(), new_firefox.to_json_api())
+        self.assertEqual(new_firefox.id.id, 6)
+
 
 class TestCollectionChangeset(TestCase):
 

--- a/tools/tests/test_resources.py
+++ b/tools/tests/test_resources.py
@@ -825,13 +825,13 @@ class TestCollectionChangeset(TestCase):
     def test_summary_new_items(self):
         _, cc = self.setup_new()
         expected = """\
-New browsers:
+New:
 {
   "browsers": {
     "slug": "chrome"
   }
 }
-New versions:
+New:
 {
   "versions": {
     "version": "2.0",
@@ -908,13 +908,13 @@ New versions:
     def test_summary_new_items_with_dependencies(self):
         _, cc = self.setup_new_with_dependencies()
         expected = """\
-New features:
+New:
 {
   "features": {
     "slug": "parent"
   }
 }
-New features:
+New:
 {
   "features": {
     "slug": "child1",
@@ -923,7 +923,7 @@ New features:
     }
   }
 }
-New features:
+New:
 {
   "features": {
     "slug": "child2",
@@ -932,7 +932,7 @@ New features:
     }
   }
 }
-New features:
+New:
 {
   "features": {
     "slug": "child3",
@@ -941,7 +941,7 @@ New features:
     }
   }
 }
-New features:
+New:
 {
   "features": {
     "slug": "grandchild",

--- a/tools/tests/test_resources.py
+++ b/tools/tests/test_resources.py
@@ -367,13 +367,13 @@ class TestSection(TestCase):
         feature = Feature(id="222")
         section = Section(
             id="_sec", specification="22", features=["222"],
-            number={"en": "1.2.3"})
+            number={"en": "1.2.3"}, subpath={"en": "#123"})
         collection = Collection()
         collection.add(maturity)
         collection.add(spec)
         collection.add(feature)
         collection.add(section)
-        self.assertEqual(('sections', '1.2.3', 'SPEC'), section.get_data_id())
+        self.assertEqual(('sections', 'SPEC', '#123'), section.get_data_id())
 
     def test_without_number(self):
         section = Section(
@@ -388,7 +388,7 @@ class TestSection(TestCase):
                 }}}
         self.assertEqual(expected, section.to_json_api())
 
-    def test_get_data_id_without_number(self):
+    def test_get_data_id_without_subpath(self):
         maturity = Maturity(id="2")
         spec = Specification(id="22", maturity="2", mdn_key="SPEC")
         feature = Feature(id="222")
@@ -398,7 +398,7 @@ class TestSection(TestCase):
         collection.add(spec)
         collection.add(feature)
         collection.add(section)
-        self.assertEqual(('sections', '', 'SPEC'), section.get_data_id())
+        self.assertEqual(('sections', 'SPEC', ''), section.get_data_id())
 
     def test_with_empty_number(self):
         section = Section(
@@ -414,18 +414,18 @@ class TestSection(TestCase):
                 }}}
         self.assertEqual(expected, section.to_json_api())
 
-    def test_get_data_id_with_empty_number(self):
+    def test_get_data_id_with_empty_subpath(self):
         maturity = Maturity(id="2")
         spec = Specification(id="22", maturity="2", mdn_key="SPEC")
         feature = Feature(id="222")
         section = Section(
-            id="_sec", specification="22", features=["222"], number={})
+            id="_sec", specification="22", features=["222"], subpath={})
         collection = Collection()
         collection.add(maturity)
         collection.add(spec)
         collection.add(feature)
         collection.add(section)
-        self.assertEqual(('sections', '', 'SPEC'), section.get_data_id())
+        self.assertEqual(('sections', 'SPEC', ''), section.get_data_id())
 
 
 class TestMaturity(TestCase):
@@ -478,7 +478,7 @@ class TestCollection(TestCase):
         specification = Specification(
             id='6', slug='css1', mdn_key='CSS1', maturity='5')
         self.col.add(specification)
-        section = Section(id='7', number={'en': '5.6.1'}, specification='6')
+        section = Section(id='7', subpath={'en': '#561'}, specification='6')
         self.col.add(section)
 
         index = self.col.get_all_by_data_id()
@@ -489,7 +489,7 @@ class TestCollection(TestCase):
             ('supports', 'the-feature', 'chrome', '1.0'): support,
             ('maturities', 'REC'): maturity,
             ('specifications', 'CSS1'): specification,
-            ('sections', '5.6.1', 'CSS1'): section,
+            ('sections', 'CSS1', '#561'): section,
         }
         self.assertEqual(expected, index)
 

--- a/tools/upload_data.py
+++ b/tools/upload_data.py
@@ -1,193 +1,63 @@
 #!/usr/bin/env python
-
-from __future__ import print_function
-
 from collections import OrderedDict
 import codecs
-import getpass
 import json
-import logging
-import os.path
-import sys
 
-from client import Client
-from resources import Collection, CollectionChangeset
-
-try:
-    input = raw_input  # Get the Py2 raw_input
-except NameError:
-    pass  # We're in Py3
-
-logger = logging.getLogger('tools.upload_data')
-
-resources = [
-    'browsers',
-    'versions',
-    'features',
-    'supports',
-    'specifications',
-    'maturities',
-    'sections',
-]
+from common import Tool
+from resources import Collection
 
 
-def upload_data(client, base_dir='', confirm=None):
-    """Upload data to the API"""
-    api_collection = Collection(client)
-    local_collection = Collection()
+class UploadData(Tool):
+    """Upload data to the API."""
+    logger_name = 'tools.upload_data'
+    parser_options = ['api', 'user', 'password', 'data']
 
-    logger.info('Reading existing data from API')
-    load_api_data(api_collection)
-    logger.info('Reading upload data from disk')
-    load_local_data(local_collection, base_dir)
+    def run(self, *args, **kwargs):
+        self.login()
+        api_collection = Collection(self.client)
+        local_collection = Collection()
+        resources = [
+            'browsers', 'versions', 'features', 'supports', 'specifications',
+            'maturities', 'sections']
 
-    logger.info('Looking for changes...')
-    changeset = CollectionChangeset(api_collection, local_collection)
-    delta = changeset.changes
+        self.logger.info('Reading existing data from API')
+        for resource in resources:
+            count = api_collection.load_all(resource)
+            self.logger.info("Downloaded %d %s.", count, resource)
 
-    if delta['new'] or delta['changed'] or delta['deleted']:
-        logger.info(
-            'Changes detected: %d new, %d changed, %d deleted, %d same.',
-            len(delta['new']), len(delta['changed']), len(delta['deleted']),
-            len(delta['same']))
-        if confirm:
-            confirmed = confirm(client, changeset)
-        else:
-            confirmed = True
-        if not confirmed:
-            return {}
-    else:
-        logger.info('No changes')
-        return {}
+        self.logger.info('Reading upload data from disk')
+        for resource in resources:
+            filepath = self.data_file('{}.json'.format(resource))
+            with codecs.open(filepath, 'r', 'utf8') as f:
+                data = json.load(f, object_pairs_hook=OrderedDict)
+            resource_class = local_collection.resource_by_type[resource]
+            for item in data[resource]:
+                obj = resource_class()
+                obj.from_json_api({resource: item})
+                local_collection.add(obj)
 
-    counts = changeset.change_original_collection()
-    return counts
+        return self.sync_changes(api_collection, local_collection)
 
+    def get_parser(self):
+        parser = super(UploadData, self).get_parser()
+        parser.add_argument(
+            '--noinput', action="store_true",
+            help='Upload any changes without prompting the user for input')
+        return parser
 
-def load_api_data(api_collection):
-    for resource in resources:
-        count = api_collection.load_all(resource)
-        logger.info("Downloaded %d %s.", count, resource)
-
-
-def load_local_data(local_collection, base_dir):
-    for resource in resources:
-        filepath = os.path.join(base_dir, '%s.json' % resource)
-        with codecs.open(filepath, 'r', 'utf8') as f:
-            data = json.load(f, object_pairs_hook=OrderedDict)
-        resource_class = local_collection.resource_by_type[resource]
-        for item in data[resource]:
-            obj = resource_class()
-            obj.from_json_api({resource: item})
-            local_collection.add(obj)
-
-
-def confirm_changes(client, changeset):
-    while True:
-        choice = input("Make these changes? (Y/N/D for details) ")
-        if choice.upper() == 'Y':
+    def confirm_changes(self, changeset):
+        if self.noinput:
             return True
-        elif choice.upper() == 'N':
-            return False
-        elif choice.upper() == 'D':
-            print(changeset.summarize())
         else:
-            print("Please type Y or N or D.")
+            return super(UploadData, self).confirm_changes(changeset)
 
 
 if __name__ == '__main__':
-    import argparse
-    description = 'Upload data to the API.'
-    parser = argparse.ArgumentParser(description=description)
-    parser.add_argument(
-        '-a', '--api',
-        help='Base URL of the API (default: http://localhost:8000)',
-        default="http://localhost:8000")
-    parser.add_argument(
-        '-u', '--user',
-        help='Username on API (default: prompt for username)')
-    parser.add_argument(
-        '-p', '--password',
-        help='Password on API (default: prompt for password)')
-    parser.add_argument(
-        '-d', '--data', default='data',
-        help='Input data folder (default: data)')
-    parser.add_argument(
-        '--noinput', action="store_true",
-        help='Upload any changes without prompting the user for input')
-    parser.add_argument(
-        '-v', '--verbose', action="store_true",
-        help='Print extra debug information')
-    parser.add_argument(
-        '-q', '--quiet', action="store_true",
-        help='Only print warnings')
-    args = parser.parse_args()
-
-    # Setup logging
-    verbose = args.verbose
-    quiet = args.quiet
-    console = logging.StreamHandler(sys.stderr)
-    formatter = logging.Formatter('%(levelname)s - %(message)s')
-    fmat = '%(levelname)s - %(message)s'
-    logger_name = 'tools'
-    if quiet:
-        level = logging.WARNING
-    elif verbose:
-        level = logging.DEBUG
-        logger_name = ''
-        fmat = '%(name)s - %(levelname)s - %(message)s'
-    else:
-        level = logging.INFO
-    formatter = logging.Formatter(fmat)
-    console.setLevel(level)
-    console.setFormatter(formatter)
-    logger = logging.getLogger(logger_name)
-    logger.setLevel(level)
-    logger.addHandler(console)
-
-    # Parse arguments
-    api = args.api
-    if api.endswith('/'):
-        api = api[:-1]
-    data = args.data
-    if data.endswith('/'):
-        data = data[:-1]
-    logger.info("Uploading data from %s to %s", data, api)
-
-    # Get credentials
-    user = args.user
-    password = args.password
-    if args.noinput and not (user and password):
+    tool = UploadData()
+    tool.init_from_command_line()
+    tool.logger.info(
+        "Uploading data from {tool.data} to {tool.api}".format(tool=tool))
+    if tool.noinput and not (tool.user and tool.password):
         raise Exception("--noinput requires --user and --password")
-    else:
-        if not user:
-            user = input("API username: ")
-        if not password:
-            password = getpass.getpass("API password: ")
-
-    # Initialize client
-    client = Client(api)
-    client.login(user, password)
-
-    # Load data
-    confirm = None if args.noinput else confirm_changes
-    counts = upload_data(client, data, confirm)
-
-    if counts:
-        logger.info("Changes complete. Counts:")
-        for resource_type, changes in counts.items():
-            c_new = changes.get('new', 0)
-            c_deleted = changes.get('deleted', 0)
-            c_changed = changes.get('changed', 0)
-            c_text = []
-            if c_new:
-                c_text.append("%d new" % c_new)
-            if c_deleted:
-                c_text.append("%d deleted" % c_deleted)
-            if c_changed:
-                c_text.append("%d changed" % c_changed)
-            if c_text:
-                logger.info("  %s: %s" % (
-                    resource_type.title(), ', '.join(c_text)))
-    else:
-        logger.info("No data uploaded.")
+    changes = tool.run()
+    tool.report_changes(changes)

--- a/webplatformcompat/drf_fields.py
+++ b/webplatformcompat/drf_fields.py
@@ -210,13 +210,16 @@ class TranslatedTextField(CharField):
         if value:
             value = value.strip()
         if value:
-            try:
-                native = json.loads(value)
-            except ValueError as e:
-                if self.allow_canonical:
-                    native = str(value)
-                else:
-                    raise ValidationError(str(e))
+            if value[0] in '"{':
+                try:
+                    native = json.loads(value)
+                except ValueError as e:
+                    if self.allow_canonical:
+                        native = value
+                    else:
+                        raise ValidationError(str(e))
+            else:
+                native = value
             if isinstance(native, six.string_types) and self.allow_canonical:
                 return {'zxx': native}
             else:

--- a/webplatformcompat/static/js/browse.js
+++ b/webplatformcompat/static/js/browse.js
@@ -391,6 +391,13 @@ Browse.Properties = {
                 i,
                 keyLen;
             if (!property) { return []; }
+            if (typeof property === 'string') {
+                outArray.push({
+                    'lang': 'canonical',
+                    'value': '<code>' + property + '</code>'
+                });
+                return outArray;
+            }
             for (key in property) {
                 if (property.hasOwnProperty(key)) {
                     if (key === 'en') {
@@ -419,6 +426,10 @@ Browse.Properties = {
                 i,
                 val;
             if (arrayLen === 0) { return '<em>none</em>'; }
+            if (arrayLen === 1 && array[0].lang === 'canonical') {
+                ul = array[0].value;
+                return ul;
+            }
             for (i = 0; i < arrayLen; i += 1) {
                 item = array[i];
                 val = item.value;

--- a/webplatformcompat/templates/webplatformcompat/feature.js.jinja2
+++ b/webplatformcompat/templates/webplatformcompat/feature.js.jinja2
@@ -114,12 +114,17 @@ function load_tables(resources, lang) {
 
 function load_json(uri) {
     $.getJSON(uri).done(function( data ) {
-        var resources, json_dump, title;
+        var resources, json_dump, title, name;
         json_dump = $("<pre>").text(JSON.stringify(data, null, "  "));
         $("#wpc_data").html(json_dump);
         window.resources = resources = WPC.parse_resources(data);
 
-        title = "Sample View for Feature '" + resources.data.name.en + "'";
+        name = WPC.trans_str(resources.data.name, 'en');
+        if (name.indexOf("<code>") === 0) {
+            title = "Sample View for Feature " + name;
+        } else {
+            title = "Sample View for Feature '" + name + "'";
+        }
         document.title = title;
         $("#body_title").html(title);
 

--- a/webplatformcompat/tests/base.py
+++ b/webplatformcompat/tests/base.py
@@ -38,8 +38,8 @@ class TestMixin(object):
             groups = ['change-resource']
         group_list = [Group.objects.get(name=g) for g in groups]
         user.groups.add(*group_list)
-        if 'change-resource' not in groups:
-            user.groups.remove(Group.objects.get(name='change-resource'))
+        # In some removed tests, had to remove the default
+        assert 'change-resource' in groups
         self.assertTrue(
             self.client.login(username=username, password=password))
         self.user = user

--- a/webplatformcompat/tests/test_drf_fields.py
+++ b/webplatformcompat/tests/test_drf_fields.py
@@ -79,6 +79,12 @@ class TestTranslatedTextField(SharedTranslatedTextFieldTests, TestCase):
         self.assertRaises(
             ValidationError, self.ttf.to_internal_value, bad_json)
 
+    def test_to_internal_value_string_true(self):
+        self.assertEqual('false', self.ttf.to_internal_value('false'))
+
+    def test_to_internal_value_list(self):
+        self.assertEqual('["list"]', self.ttf.to_internal_value('["list"]'))
+
 
 class TestCanonTranslatedTextField(SharedTranslatedTextFieldTests, TestCase):
 
@@ -100,6 +106,13 @@ class TestCanonTranslatedTextField(SharedTranslatedTextFieldTests, TestCase):
         bad_json = "{'quotes': 'wrong ones'}"
         expected = {"zxx": "{'quotes': 'wrong ones'}"}
         self.assertEqual(expected, self.ttf.to_internal_value(bad_json))
+
+    def test_to_internal_value_string_true(self):
+        self.assertEqual({'zxx': 'false'}, self.ttf.to_internal_value('false'))
+
+    def test_to_internal_value_list(self):
+        self.assertEqual(
+            {'zxx': '["list"]'}, self.ttf.to_internal_value('["list"]'))
 
 
 class SharedOptionalCharFieldTests(object):


### PR DESCRIPTION
*This PR builds on previous PRs, and can be rebased*

If a page doesn't contain a specification or browser compatibility header, or the CompatibilityTable KumaScript macro, then consider it "No Data" and don't parse.  Speeds up a full re-parse by 30%, and reduces issues.  The biggest drop is in ``doc_parse_error``, from 405 to 17.  ``section_skipped`` also dropped from 2200 to 1604.  This is less expected, but is due to pages like [Web/API/PowerManager/removeWakeLockListener](https://developer.mozilla.org/en-US/docs/Web/API/PowerManager/removeWakeLockListener), which has a section named "Specification" (not "Specifications"), no browser compatibility data, and no actual specification data to speak of.

        Issue Slug         | Old Count | New Count
---------------------------|-----------|----------
**Total**                  |      7091 |      6103
section_skipped            |      2200 |      1604
inline_text                |      1896 |      1896
unexpected_attribute       |       488 |       488
doc_parse_error            |       405 |        17
spec2_converted            |       283 |       283
unknown_kumascript         |       272 |       272
skipped_h3                 |       262 |       262
unknown_version            |       221 |       221
specname_converted         |       193 |       193
halt_import                |       155 |       151
footnote_missing           |       106 |       106
specname_not_kumascript    |        98 |        98
missing_attribute          |        98 |        98
footnote_no_id             |        75 |        75
footnote_unused            |        59 |        59
unknown_browser            |        42 |        42
section_missed             |        40 |        40
spec_h2_id                 |        38 |        38
footnote_multiple          |        38 |        38
spec_h2_name               |        32 |        32
tag_dropped                |        22 |        22
unknown_spec               |        21 |        21
span_dropped               |        12 |        12
second_footnote            |        12 |        12
spec_mismatch              |        10 |        10
compatgeckodesktop_unknown |        10 |        10
footnote_feature           |         2 |         2
spec2_wrong_kumascript     |         1 |         1